### PR TITLE
Exposing 'getModelEndpointUrl' among other public helpers

### DIFF
--- a/packages/datx-jsonapi/src/helpers/model.ts
+++ b/packages/datx-jsonapi/src/helpers/model.ts
@@ -237,7 +237,7 @@ export function modelToJsonApi(model: IJsonapiModel): IRecord {
   return data;
 }
 
-function getModelEndpointUrl(model: IJsonapiModel, options?: IRequestOptions): string {
+export function getModelEndpointUrl(model: IJsonapiModel, options?: IRequestOptions): string {
   const queryData = prepareQuery(
     getModelType(model),
     isModelPersisted(model) ? getModelId(model) : undefined,

--- a/packages/datx-jsonapi/src/index.ts
+++ b/packages/datx-jsonapi/src/index.ts
@@ -11,6 +11,7 @@ export {
   getModelMeta,
   getModelRefLinks,
   getModelRefMeta,
+  getModelEndpointUrl,
   modelToJsonApi,
   saveModel,
   saveRelationship,


### PR DESCRIPTION
I would like to use this helper in my custom collection requests (RPC actions). 

For now I have to duplicate the package inside logic of getting endpoint:

```js
const collection = getModelCollection(model) as IJsonapiCollection;
const modelType = getModelType(model);

const staticCollection = collection.constructor as typeof PureCollection;
const ModelClass = staticCollection.types.filter(
  item => item.type === modelType
);

// create endpoint
const endpoint = _.get(ModelClass, [0, 'endpoint'], 'dummy');

// create id
const id = getModelId(model) || 0;

// create request
return collection.request(
  `${endpoint}/${id}/${action}`,
  method || 'POST',
  data,
  options
);
```

With this helper exposed it is much simplier:

```js
const collection = getModelCollection(model) as IJsonapiCollection;
const endpoint = getModelEndpointUrl(model);

collection.request(
    `${endpoint}/${action}`,
    method || 'POST',
    data,
    options
);  
```