### PR TITLE
Possibilty explicitly set IJsonapiView incoming model type

### DIFF
--- a/packages/datx-jsonapi/src/interfaces/IJsonapiView.ts
+++ b/packages/datx-jsonapi/src/interfaces/IJsonapiView.ts
@@ -5,15 +5,15 @@ import { IJsonapiModel } from './IJsonapiModel';
 import { IRequestOptions } from './IRequestOptions';
 import { IResponse } from './JsonApi';
 
-export interface IJsonapiView extends View {
-  sync<T extends IJsonapiModel = IJsonapiModel>(body?: IResponse): T | Array<T> | null;
+export interface IJsonapiView<T extends IJsonapiModel = IJsonapiModel> extends View<T> {
+  sync(body?: IResponse): T | Array<T> | null;
 
-  fetch<T extends IJsonapiModel = IJsonapiModel>(
+  fetch(
     id: number | string,
     options?: IRequestOptions,
   ): Promise<Response<T>>;
 
-  fetchAll<T extends IJsonapiModel = IJsonapiModel>(
+  fetchAll(
     options?: IRequestOptions,
   ): Promise<Response<T>>;
 }


### PR DESCRIPTION
Just small TS fix but really usefull - described below:

```ts
export type IStoreRemoteDataView<T extends IJsonapiModel = IJsonapiModel> = IJsonapiView<T>;

export class StoreRemoteDataView extends jsonapi(View) {}

// valid retyping = no ts errors
const view = new StoreRemoteDataView(...) as IStoreRemoteDataView<MyModel>;

// view.list has now proper type of MyModel[]
view.list.map(model => (
  // ... here my TS compiler knows that model is type of MyModel
))
```