### PR TITLE
Feature/query string encoding

### DIFF
--- a/packages/datx-jsonapi/package.json
+++ b/packages/datx-jsonapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datx-jsonapi",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "DatX mixin for JSON API support",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/packages/datx-jsonapi/src/NetworkUtils.ts
+++ b/packages/datx-jsonapi/src/NetworkUtils.ts
@@ -40,6 +40,7 @@ export interface IConfigType {
   defaultFetchOptions: IDictionary;
   fetchReference?: typeof fetch;
   paramArrayType: ParamArrayType;
+  encodeQueryString?: boolean;
   onError(IResponseObject): IResponseObject;
   transformRequest(options: ICollectionFetchOpts): ICollectionFetchOpts;
   transformResponse(response: IRawResponse): IRawResponse;
@@ -58,6 +59,8 @@ export const config: IConfigType = {
       'content-type': 'application/vnd.api+json',
     },
   },
+
+  encodeQueryString: false,
 
   // Reference of the fetch method that should be used
   fetchReference: isBrowser && 'fetch' in window && typeof window.fetch === 'function' && window.fetch.bind(window)

--- a/packages/datx-jsonapi/src/helpers/url.ts
+++ b/packages/datx-jsonapi/src/helpers/url.ts
@@ -41,13 +41,17 @@ export function prepareQuery(
 export function buildUrl(url: string, data?: IRequest, options?: IRequestOptions) {
   const headers: IDictionary<string> = (options && options.headers) || { };
 
-  const params: Array<string> = [
+  let params: Array<string> = [
     ...prepareFilters((options && options.filter) || { }),
     ...prepareSort(options && options.sort),
     ...prepareIncludes(options && options.include),
     ...prepareFields((options && options.fields) || { }),
     ...prepareRawParams((options && options.params) || []),
   ];
+
+  if (config.encodeQueryString) {
+    params = params.map(encodeParam);
+  }
 
   const baseUrl: string = appendParams(prefixUrl(url), params);
 
@@ -126,4 +130,9 @@ function parametrize(params: object, scope: string = '') {
   });
 
   return list;
+}
+
+function encodeParam(param: string) {
+  // Manually decode field-value separator (=)
+  return encodeURIComponent(param).replace('%3D', '=');
 }

--- a/packages/datx-jsonapi/test/network/params.ts
+++ b/packages/datx-jsonapi/test/network/params.ts
@@ -252,4 +252,35 @@ describe('params', () => {
     expect(events.data).toBeInstanceOf(Array);
     expect(events.data).toHaveLength(4);
   });
+
+  describe('query string encoding', () => {
+    afterEach(() => {
+      config.encodeQueryString = false;
+    });
+
+    it("shouldn't encode params by default", async () => {
+      mockApi({
+        name: 'events-1',
+        query: false,
+        url: 'event?filter[name]=ć',
+      });
+
+      const store = new TestStore();
+      await store.request('event', 'GET', undefined, { filter: { name: 'ć' } });
+    });
+
+    it('should encode params when enabled', async () => {
+      config.encodeQueryString = true;
+
+      mockApi({
+        name: 'events-1',
+        query: false,
+        url: 'event?filter%5Bname%5D=%C4%87%3D',
+      });
+
+      const store = new TestStore();
+      await store.request('event', 'GET', undefined, { filter: { name: 'ć=' } });
+    });
+
+  });
 });


### PR DESCRIPTION
URL query string isn't encoded by default, meaning it could contain characters which are unsafe (e.g. arbitrary string from user input with non-ASCII characters). This PR introduces `encodeQueryString` option in network config which when enabled encodes all query params passed to the URL.

Note: `encodeQueryString` is turned off by default, for backwards compatibility. However, it should probably be enabled by default in a breaking release of the library, since it's desired behavior to always encode query string.