### PR TITLE
Add the `prop.alias` API to generate a shortcut for the `ID attribute` of the `Ref field`

### DIFF
--- a/packages/datx/src/helpers/model/utils.ts
+++ b/packages/datx/src/helpers/model/utils.ts
@@ -104,7 +104,7 @@ export function getOriginalModel<T extends PureModel = PureModel>(model: T): T {
   throw error(NOT_A_CLONE);
 }
 
-const READ_ONLY_META = ['fields', 'id', 'refs', 'type'];
+const READ_ONLY_META = ['fields', 'id', 'refs', 'type', 'alias'];
 
 /**
  * Bulk update the model data

--- a/packages/datx/src/helpers/utils.ts
+++ b/packages/datx/src/helpers/utils.ts
@@ -1,0 +1,47 @@
+
+export function unique(arr: Array<any>): Array<any> {
+  return arr.filter((v, i, a) => a.indexOf(v) === i);
+}
+
+export function mergeAsArray(obj: object, key: string, value: any | Array<any>): object {
+  const target = Object.assign({ }, obj);
+  if (!target[key]) {
+    target[key] = [].concat(value);
+
+    return target;
+  }
+  target[key] = unique([].concat(target[key], value));
+
+  return target;
+}
+
+export function reverseObjectKV(obj: object) {
+  return Object.keys(obj).reduce((map, key) => {
+    let __keys = obj[key];
+
+    if (!Array.isArray(obj[key])) {
+      __keys = [obj[key]];
+    }
+
+    __keys.forEach((_key) => {
+      map[_key] = (map[_key] && map[_key].concat(key)) || [key];
+    });
+
+    return map;
+  }, { });
+}
+
+export function peekValue(data: object, keys: Array<string>): any {
+  if (data === undefined || keys === undefined) { return undefined; }
+  let oo;
+  let i = -1;
+  while (++i < keys.length) {
+    const _v = data[keys[i]];
+    if (_v !== undefined && _v !== null) {
+        oo = _v;
+        break;
+      }
+  }
+
+  return oo;
+}

--- a/packages/datx/src/mixins/setupModel.ts
+++ b/packages/datx/src/mixins/setupModel.ts
@@ -18,12 +18,14 @@ export function setupModel<IModel extends PureModel, IFields extends IDictionary
     type,
     idAttribute,
     typeAttribute,
+    alias,
   }: {
     fields: IFields;
     references?: IDictionary<IReferenceOptions>;
     type?: IType;
     idAttribute?: string;
     typeAttribute?: string;
+    alias?: IDictionary<Array<string>>;
   // tslint:disable-next-line:no-object-literal-type-assertion
   } = { fields: { } as IFields },
 ) {
@@ -70,6 +72,12 @@ export function setupModel<IModel extends PureModel, IFields extends IDictionary
 
           return;
       }
+    });
+  }
+
+  if (alias) {
+    Object.keys(alias).forEach((key) => {
+        prop.alias(alias[key])(ModelWithProps.prototype, key);
     });
   }
 

--- a/packages/datx/src/mixins/withMeta.ts
+++ b/packages/datx/src/mixins/withMeta.ts
@@ -67,6 +67,10 @@ export function withMeta<T extends PureModel = PureModel>(Base: IModelConstructo
     @computed public get type() {
       return getModelType(this.__instance);
     }
+
+    @computed public get alias() {
+      return getModelMetaKey(this.__instance, 'alias') || { };
+    }
   }
 
   // tslint:disable-next-line:max-classes-per-file

--- a/packages/datx/src/prop.ts
+++ b/packages/datx/src/prop.ts
@@ -126,6 +126,18 @@ export const prop = Object.assign(propFn, {
     storage.addModelDefaultField(getClass(obj), key);
     storage.setModelClassMetaKey(getClass(obj), 'type', key);
   },
+
+  /**
+   *  Define the field alias property on the model
+   * @param refKey {string | Array<string>}
+   */
+  alias(refKey: string | Array<string>): (obj: PureModel, key: string) => void {
+    return <T extends PureModel>(obj: T, key: string, opts?: object) => {
+      prepareDecorator(obj, key, opts);
+      storage.addModelDefaultField(getClass(obj), key);
+      storage.addModelClassFieldAlias(getClass(obj), key, refKey);
+    };
+  },
 });
 
 export function view<TCollection extends PureCollection, TModel extends PureModel>(

--- a/packages/datx/src/services/storage.ts
+++ b/packages/datx/src/services/storage.ts
@@ -4,6 +4,7 @@ import { observable, set } from 'mobx';
 import { MODEL_REQUIRED } from '../errors';
 import { error } from '../helpers/format';
 import { reducePrototypeChain } from '../helpers/selectors';
+import { mergeAsArray } from '../helpers/utils';
 import { IDataStorage } from '../interfaces/IDataStorage';
 import { IReferenceOptions } from '../interfaces/IReferenceOptions';
 import { PureModel } from '../PureModel';
@@ -129,6 +130,19 @@ export class DataStorage {
         data: { },
         meta: { },
         references: { [key]: options },
+      });
+    }
+  }
+
+  public addModelClassFieldAlias(model: typeof PureModel, key: string, refKey: string | Array<string>) {
+    const data = model[DATX_KEY];
+    if (data) {
+      data.meta.alias = mergeAsArray(data.meta.alias, key, refKey);
+    } else {
+      setMeta(model, {
+        data: { },
+        meta: { alias: { [key]: refKey } },
+        references: { },
       });
     }
   }

--- a/packages/datx/test/__snapshots__/patches.ts.snap
+++ b/packages/datx/test/__snapshots__/patches.ts.snap
@@ -63,6 +63,7 @@ Array [
     },
     "oldValue": Object {
       "__META__": Object {
+        "alias": Object {},
         "fields": Array [
           "name",
           "nick",
@@ -215,6 +216,7 @@ Array [
     },
     "newValue": Object {
       "__META__": Object {
+        "alias": Object {},
         "fields": Array [
           "id",
         ],
@@ -248,6 +250,7 @@ Array [
     },
     "newValue": Object {
       "__META__": Object {
+        "alias": Object {},
         "fields": Array [
           "id",
         ],

--- a/packages/datx/test/prop.alias.ts
+++ b/packages/datx/test/prop.alias.ts
@@ -1,0 +1,124 @@
+// tslint:disable:max-classes-per-file
+import { configure } from 'mobx';
+
+configure({ enforceActions: 'observed' });
+
+import { Collection, Model, prop } from '../src';
+
+describe('prop.alias', () => {
+  it('should be set value to alias property', () => {
+    class Person extends Model {
+      public static type = 'person';
+
+      @prop.identifier public id!: number;
+      @prop public firstName!: string;
+      @prop public lastName!: string;
+
+      @prop.toOne(Person) public spouse!: Person;
+      @prop.alias('spouse') public spouseId!: number;
+    }
+
+    class Store extends Collection {
+      public static types = [Person];
+    }
+
+    const store = new Store();
+
+    const john = store.add<Person>({ firstName: 'John', lastName: 'Doe', id: 111 }, Person);
+    const jane = store.add<Person>({ firstName: 'Jane', lastName: 'Doe', id: 222 }, 'person');
+    expect(john.spouse).toBe(undefined);
+    john.spouse = jane;
+    expect(john.spouse).toBe(jane);
+    expect(john.spouseId).toBe(jane.id);
+
+    const jane2 = store.add<Person>({ firstName: 'Jane2', lastName: 'Doe2', id: 333 }, 'person');
+    john.spouseId = 333;
+    expect(john.spouse).toBe(jane2);
+
+  });
+
+  it('should be set value in multi alias property', () => {
+    class Person extends Model {
+      public static type = 'person';
+
+      @prop.identifier public id!: number;
+      @prop public firstName!: string;
+      @prop public lastName!: string;
+
+      @prop.toOne(Person) public spouse!: Person;
+      @prop.alias('spouse') public spouseId!: number;
+      @prop.alias('spouse') public spouseId2!: number;
+    }
+
+    class Store extends Collection {
+      public static types = [Person];
+    }
+
+    const store = new Store();
+
+    const john = store.add<Person>({ firstName: 'John', lastName: 'Doe', id: 111 }, Person);
+    const jane = store.add<Person>({ firstName: 'Jane', lastName: 'Doe', id: 222 }, 'person');
+
+    expect(john.spouse).toBe(undefined);
+    john.spouse = jane;
+    expect(john.spouseId).toBe(jane.id);
+    expect(john.spouseId2).toBe(jane.id);
+
+    const jane2 = store.add<Person>({ firstName: 'Jane2', lastName: 'Doe2', id: 333 }, 'person');
+    john.spouseId2 = jane2.id;
+    expect(john.spouseId).toBe(jane.id);
+    expect(john.spouse.id).toBe(jane2.id);
+  });
+
+  it('should be set value at initialize on ref side', () => {
+    class Person extends Model {
+      public static type = 'person';
+
+      @prop.identifier public id!: number;
+      @prop public firstName!: string;
+      @prop public lastName!: string;
+
+      @prop.toOne(Person) public spouse!: Person;
+      @prop.alias('spouse') public spouseId!: number;
+      @prop.alias('spouse') public spouseId2!: number;
+    }
+
+    class Store extends Collection {
+      public static types = [Person];
+    }
+
+    const store = new Store();
+
+    const jane = store.add<Person>({ firstName: 'Jane', lastName: 'Doe', id: 222 }, 'person');
+    const john = store.add<Person>({ firstName: 'John', lastName: 'Doe', id: 111, spouse : 222 }, Person);
+
+    expect(john.spouseId).toBe(jane.id);
+    expect(john.spouse).toBe(jane);
+  });
+
+  it('should be set value at initialize on alias side', () => {
+    class Person extends Model {
+      public static type = 'person';
+
+      @prop.identifier public id!: number;
+      @prop public firstName!: string;
+      @prop public lastName!: string;
+
+      @prop.toOne(Person) public spouse!: Person;
+      @prop.alias('spouse') public spouseId!: number;
+      @prop.alias('spouse') public spouseId2!: number;
+    }
+
+    class Store extends Collection {
+      public static types = [Person];
+    }
+
+    const store = new Store();
+
+    const jane = store.add<Person>({ firstName: 'Jane', lastName: 'Doe', id: 222 }, 'person');
+    const john = store.add<Person>({ firstName: 'John', lastName: 'Doe', id: 111, spouseId : 222 }, Person);
+
+    expect(john.spouseId).toBe(jane.id);
+    expect(john.spouse).toBe(jane);
+  });
+});


### PR DESCRIPTION
```typescript

   class Person extends Model {
      public static type = 'person';

      @prop.toOne(Person) public spouse!: Person;
      @prop.alias('spouse') public spouseId!: number;
    }

/*
 if   person.spouse = otherPerson;
 person.spouseId will be auto set value by otherPersion.id

if   person.spouseId = otherPersion.id 
 person.spouse will be auto set value by otherPerson
*/
```