### PR TITLE
+ fix bug: the initialVal was not handled correctly before initializing ref to add the bucket

### DIFF
--- a/packages/datx/src/PureCollection.ts
+++ b/packages/datx/src/PureCollection.ts
@@ -189,7 +189,8 @@ export class PureCollection {
       return this.__findOneByType((model as IModelRef).type, (model as IModelRef).id);
     }
 
-    if (!id) {
+    if (id === null || id === undefined) {
+      // ID mybe `""` or `0`
       throw new Error('The identifier is missing');
     }
 
@@ -423,7 +424,7 @@ export class PureCollection {
 
     const existingModel = this.findOne(modelType, modelId);
 
-    if (existingModel) {
+    if (existingModel && existingModel !== model) {
       updateModel(existingModel, model);
 
       return;

--- a/packages/datx/src/helpers/model/fields.ts
+++ b/packages/datx/src/helpers/model/fields.ts
@@ -13,6 +13,7 @@ import { PureModel } from '../../PureModel';
 import { IBucket } from '../../interfaces/IBucket';
 import { TRefValue } from '../../interfaces/TRefValue';
 import { IIdentifier } from '../../interfaces/IIdentifier';
+import { getModelRefType } from './init';
 import { getModelCollection, getModelId, getModelRef, getModelType, isIdentifier } from './utils';
 import { IFieldDefinition, IReferenceDefinition } from '../../Attribute';
 import { MetaModelField } from '../../enums/MetaModelField';
@@ -41,9 +42,15 @@ export function updateRef(
 ): PureModel | Array<PureModel> | null {
   const bucket: IBucket<PureModel> | undefined = getMeta(model, `ref_${key}`);
 
-  if (isIdentifier(value) || Array.isArray(value)) {
+  if (isIdentifier(value) || isArrayLike(value)) {
     const fieldDef = getMeta(model, MetaModelField.Fields, {})[key];
-    const type = fieldDef.referenceDef.model;
+    const type = getModelRefType(
+      fieldDef.referenceDef.model,
+      fieldDef.referenceDef.defaultValue,
+      model,
+      key,
+      getModelCollection(model),
+    );
     value = mapItems(value, (v: IIdentifier | IModelRef | PureModel) =>
       isIdentifier(v) ? { id: v, type } : getModelRef(v),
     );

--- a/packages/datx/src/helpers/model/fields.ts
+++ b/packages/datx/src/helpers/model/fields.ts
@@ -1,4 +1,4 @@
-import { getMeta, setMeta, warn } from 'datx-utils';
+import { getMeta, setMeta, warn, mapItems } from 'datx-utils';
 import {
   runInAction,
   IObservableArray,
@@ -13,7 +13,7 @@ import { PureModel } from '../../PureModel';
 import { IBucket } from '../../interfaces/IBucket';
 import { TRefValue } from '../../interfaces/TRefValue';
 import { IIdentifier } from '../../interfaces/IIdentifier';
-import { getModelCollection, getModelId, getModelType } from './utils';
+import { getModelCollection, getModelId, getModelRef, getModelType, isIdentifier } from './utils';
 import { IFieldDefinition, IReferenceDefinition } from '../../Attribute';
 import { MetaModelField } from '../../enums/MetaModelField';
 import { MetaClassField } from '../../enums/MetaClassField';
@@ -40,6 +40,14 @@ export function updateRef(
   value: TRefValue,
 ): PureModel | Array<PureModel> | null {
   const bucket: IBucket<PureModel> | undefined = getMeta(model, `ref_${key}`);
+
+  if (isIdentifier(value) || Array.isArray(value)) {
+    const fieldDef = getMeta(model, MetaModelField.Fields, {})[key];
+    const type = fieldDef.referenceDef.model;
+    value = mapItems(value, (v: IIdentifier | IModelRef | PureModel) =>
+      isIdentifier(v) ? { id: v, type } : getModelRef(v),
+    );
+  }
 
   return bucket ? (bucket.value = value) : null;
 }

--- a/packages/datx/src/helpers/model/init.ts
+++ b/packages/datx/src/helpers/model/init.ts
@@ -71,7 +71,7 @@ export function initModelRef<T extends PureModel>(
     );
   } else {
     const Bucket = getBucketConstructor(fieldDef.referenceDef.type);
-    let value: IType | Array<IType> | null =
+    let value: IType | Array<IType> | IModelRef | Array<IModelRef> | null =
       fieldDef.referenceDef.type === ReferenceType.TO_MANY ? [] : null;
 
     if (initialVal) {
@@ -93,7 +93,7 @@ export function initModelRef<T extends PureModel>(
           collection?.findOne(
             getModelRefType(fieldDef.referenceDef.model, item, model, key, collection),
             item,
-          ) || null
+          ) || ({ id: item, type: fieldDef.referenceDef.model } as IModelRef)
         );
       });
     }

--- a/packages/datx/src/helpers/model/init.ts
+++ b/packages/datx/src/helpers/model/init.ts
@@ -26,7 +26,7 @@ import { IType } from '../../interfaces/IType';
 
 type ModelFieldDefinitions = Record<string, IFieldDefinition>;
 
-function getModelRefType(
+export function getModelRefType(
   model: ParsedRefModel,
   data: any,
   parentModel: PureModel,
@@ -93,7 +93,11 @@ export function initModelRef<T extends PureModel>(
           collection?.findOne(
             getModelRefType(fieldDef.referenceDef.model, item, model, key, collection),
             item,
-          ) || ({ id: item, type: fieldDef.referenceDef.model } as IModelRef)
+          ) ||
+          ({
+            id: item,
+            type: getModelRefType(fieldDef.referenceDef.model, item, model, key, collection),
+          } as IModelRef)
         );
       });
     }

--- a/packages/datx/src/helpers/model/init.ts
+++ b/packages/datx/src/helpers/model/init.ts
@@ -86,7 +86,7 @@ export function initModelRef<T extends PureModel>(
         }
 
         if (typeof item === 'object' && isModelReference(item)) {
-          return collection?.findOne(item as IModelRef) || null;
+          return collection?.findOne(item as IModelRef) || (item as IModelRef);
         }
 
         return (

--- a/packages/datx/src/helpers/model/utils.ts
+++ b/packages/datx/src/helpers/model/utils.ts
@@ -65,6 +65,10 @@ export function isModelReference(value: unknown): boolean {
   );
 }
 
+export function isIdentifier(value: any): boolean {
+  return typeof value === 'string' || typeof value === 'number';
+}
+
 /**
  * Get the type of the given model
  *
@@ -232,7 +236,8 @@ export function assignModel<T extends PureModel>(model: T, key: string, value: a
     }
     const fields: Record<string, IFieldDefinition> = getMeta(model, MetaModelField.Fields, {});
     const shouldBeReference =
-      (isArrayLike(value) && value[0] instanceof PureModel) || value instanceof PureModel;
+      (isArrayLike(value) && value.length > 0 && value[0] instanceof PureModel) ||
+      value instanceof PureModel;
 
     if (key in fields) {
       if (shouldBeReference && !fields[key].referenceDef) {

--- a/packages/datx/test/collection.ts
+++ b/packages/datx/test/collection.ts
@@ -1,6 +1,6 @@
 import { autorun, configure } from 'mobx';
 
-import { Collection, PureModel, Attribute, updateModelId, Model } from '../src';
+import { Collection, PureModel, Attribute, updateModelId, Model, getRefId } from '../src';
 import { isCollection, isModel } from '../src/helpers/mixin';
 import { getModelCollection, getModelId } from '../src/helpers/model/utils';
 
@@ -445,6 +445,10 @@ describe('Collection', () => {
       expect(jane.toy).toBe(toy10);
       jane.toy = store.add([{ id: 11 }, { id: 12 }], Toy);
       expect(jane.toy.map((d) => d.id)).toEqual([11, 12]);
+
+      const store2 = new Store();
+      const steve2 = store2.add<Person>({ spouse: { id: 1, type: 'person' }, id: 1 }, Person);
+      expect(getRefId(steve2, 'spouse')).toEqual({ id: 1, type: 'person' });
     });
   });
 });


### PR DESCRIPTION
 after a model is added to a collection. The `id` is referenced in the collection before it is added, and after the `id(model)` is added to the collection, the newly added `id(model)` is still not referenced correctly.

the reason is that the `initialVal` was not handled correctly before initializing ref to add the `bucket`