### PR TITLE
Fix add raw data does not contain ref data multi times, `ToMany` will throw an exception

### DIFF
--- a/packages/datx/src/buckets/ToMany.ts
+++ b/packages/datx/src/buckets/ToMany.ts
@@ -79,6 +79,8 @@ export class ToMany<T extends PureModel> {
   public set value(data: Array<T>) {
     if (this.__readonly) {
       throw error('This is a read-only bucket');
+    } else if (data === null) {
+      data = [];
     } else if (!isArrayLike(data)) {
       throw error('The reference must be an array of values.');
     }

--- a/packages/datx/src/helpers/model/init.ts
+++ b/packages/datx/src/helpers/model/init.ts
@@ -50,6 +50,8 @@ function getRefValue<T extends PureModel>(
   key: string,
 ): TRefValue<T> {
   return mapItems(value, (item) => {
+    if (item === null || item === undefined) return null;
+
     if (typeof item === 'object' && !isModelReference(item)) {
       return (
         collection?.add(

--- a/packages/datx/test/collection.ts
+++ b/packages/datx/test/collection.ts
@@ -548,5 +548,38 @@ describe('Collection', () => {
       expect(store.findAll(Foo).length).toBe(1);
       expect(store.findAll(Bar).length).toBe(1);
     });
+
+    it('should be set raw (ref) data multi times', () => {
+      class Foo extends Model {
+        static type = 'foo';
+        @Attribute({ isIdentifier: true }) public key!: string;
+        @Attribute() public name!: string;
+        @Attribute({ toMany: Foo }) public children!: Foo[];
+      }
+
+      class Store extends Collection {
+        static types = [Foo];
+      }
+
+      const store = new Store();
+      store.add(
+        {
+          key: '0',
+          name: 'foo0',
+        },
+        Foo,
+      );
+      store.add(
+        {
+          key: '0',
+          name: 'foo1',
+        },
+        Foo,
+      );
+      expect(store.findAll(Foo).length).toBe(1);
+      const foo = store.findOne<Foo>(Foo, '0');
+      expect(foo!.name).toBe('foo1');
+      expect(foo!.children).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
`store.add` on the second call, the `ref setter` is called with 'undefined' as the `newValue` even if it does not contain a `toMany ref property`, but the `ToMany Bucket `s value setter is not accept `null` value .