### PR TITLE
Fix use `id/ids` to define an indirect reference exception

### DIFF
--- a/packages/datx/package.json
+++ b/packages/datx/package.json
@@ -48,6 +48,7 @@
       "js"
     ],
     "testRegex": "test/(.*).ts$",
+    "testPathIgnorePatterns": ["test/__models__/*"],
     "globals": {
       "ts-jest": {
         "diagnostics": {

--- a/packages/datx/src/helpers/model/init.ts
+++ b/packages/datx/src/helpers/model/init.ts
@@ -28,7 +28,7 @@ import { IType } from '../../interfaces/IType';
 type ModelFieldDefinitions = Record<string, IFieldDefinition>;
 
 export function getModelRefType(
-  model: ParsedRefModel,
+  model: ParsedRefModel | IType,
   data: any,
   parentModel: PureModel,
   key: string,
@@ -112,6 +112,7 @@ export function initModelRef<T extends PureModel>(
     let value: TRefValue = fieldDef.referenceDef.type === ReferenceType.TO_MANY ? [] : null;
 
     if (initialVal !== null && initialVal !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value = getRefValue(initialVal, collection!, fieldDef, model, key);
     }
 
@@ -126,6 +127,7 @@ export function initModelRef<T extends PureModel>(
       () => getRef(model, key),
       (newValue: TRefValue) => {
         updateSingleAction(model, key, newValue);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         updateRef(model, key, getRefValue(newValue, collection!, fieldDef, model, key));
       },
     );

--- a/packages/datx/src/helpers/model/utils.ts
+++ b/packages/datx/src/helpers/model/utils.ts
@@ -19,7 +19,7 @@ import { IIdentifier } from '../../interfaces/IIdentifier';
 import { startAction, endAction } from '../patch';
 import { MetaClassField } from '../../enums/MetaClassField';
 import { initModelField } from './init';
-import { IFieldDefinition } from '../../Attribute';
+import { IFieldDefinition, IReferenceDefinition } from '../../Attribute';
 import { IBucket } from '../../interfaces/IBucket';
 import { error } from '../format';
 import { ReferenceType } from '../../enums/ReferenceType';
@@ -257,10 +257,13 @@ export function assignModel<T extends PureModel>(model: T, key: string, value: a
       value instanceof PureModel;
 
     if (key in fields) {
-      if (shouldBeReference && !fields[key].referenceDef) {
+      const referenceDef = fields[key].referenceDef as IReferenceDefinition;
+      if (shouldBeReference && !referenceDef) {
         throw error('You should save this value as a reference.');
       }
-      model[key] = value;
+      if (!(referenceDef?.property && value === undefined)) {
+        model[key] = value;
+      }
     } else {
       if (shouldBeReference) {
         extendObservable(fields, {

--- a/packages/datx/test/__models__/Person.ts
+++ b/packages/datx/test/__models__/Person.ts
@@ -1,0 +1,16 @@
+import { Attribute, Model } from '../../src';
+import Pet from './Pet';
+import Toy from './Toy';
+
+export default class Person extends Model {
+  static type = 'person';
+
+  @Attribute({ isIdentifier: true }) id!: number;
+
+  @Attribute() public firstName!: string;
+
+  @Attribute() public lastName!: string;
+
+  @Attribute({ toMany: Pet, referenceProperty: 'owner' }) pets!: Array<Pet>;
+  @Attribute({ toMany: Toy, referenceProperty: 'owners' }) toys!: Array<Toy>;
+}

--- a/packages/datx/test/__models__/Pet.ts
+++ b/packages/datx/test/__models__/Pet.ts
@@ -1,0 +1,8 @@
+import { Attribute, Model } from '../../src';
+import Person from './Person';
+export default class Pet extends Model {
+  static type = 'pet';
+
+  @Attribute() public name!: string;
+  @Attribute({ toOne: () => Person }) public owner!: Person;
+}

--- a/packages/datx/test/__models__/Toy.ts
+++ b/packages/datx/test/__models__/Toy.ts
@@ -1,0 +1,9 @@
+import { Attribute, Model } from '../../src';
+import Person from './Person';
+
+export default class Toy extends Model {
+  static type = 'toy';
+
+  @Attribute() public name!: string;
+  @Attribute({ toMany: () => Person }) public owners!: Person[];
+}

--- a/packages/datx/test/collection.ts
+++ b/packages/datx/test/collection.ts
@@ -11,6 +11,9 @@ import {
 } from '../src';
 import { isCollection, isModel } from '../src/helpers/mixin';
 import { getModelCollection, getModelId } from '../src/helpers/model/utils';
+import Person from './__models__/Person';
+import Pet from './__models__/Pet';
+import Toy from './__models__/Toy';
 
 configure({ enforceActions: 'observed' });
 
@@ -578,8 +581,117 @@ describe('Collection', () => {
       );
       expect(store.findAll(Foo).length).toBe(1);
       const foo = store.findOne<Foo>(Foo, '0');
-      expect(foo!.name).toBe('foo1');
-      expect(foo!.children).toEqual([]);
+      expect(foo?.name).toBe('foo1');
+      expect(foo?.children).toEqual([]);
+    });
+
+    it('should be use model for indirect references', () => {
+      class MyCollection extends Collection {
+        static types = [Person, Pet];
+      }
+
+      const collection = new MyCollection();
+
+      collection.add<Person>({ firstName: 'Jane', id: 1 }, Person);
+      const steve = collection.add<Person>({ firstName: 'Steve', spouse: 1 }, Person);
+      const fido = collection.add<Pet>({ name: 'Fido', owner: steve }, Pet);
+
+      expect(fido.owner).toBe(steve);
+      expect(steve.pets.length).toBe(1);
+      expect(steve.pets[0].name).toBe(fido.name);
+    });
+
+    it('should be use id for indirect references', () => {
+      class MyCollection extends Collection {
+        static types = [Person, Pet];
+      }
+
+      const collection = new MyCollection();
+
+      collection.add<Person>({ firstName: 'Jane', id: 1 }, Person);
+      const steve = collection.add<Person>({ firstName: 'Steve', spouse: 1 }, Person);
+      const fido = collection.add<Pet>({ name: 'Fido', owner: steve.id }, Pet);
+      const wufi = collection.add<Pet>({ name: 'wufi', owner: steve.id }, Pet);
+
+      expect(fido.owner).toBe(steve);
+      expect(steve.pets.length).toBe(2);
+      expect(steve.pets[0].name).toBe(fido.name);
+      expect(steve.pets[1].name).toBe(wufi.name);
+      collection.removeOne(wufi);
+      expect(steve.pets.length).toBe(1);
+      expect(steve.pets[0].name).toBe(fido.name);
+    });
+
+    it('should be use ids for indirect references', () => {
+      class MyCollection extends Collection {
+        static types = [Person, Pet, Toy];
+      }
+
+      const collection = new MyCollection();
+
+      collection.add<Person>({ firstName: 'Jane', id: 1 }, Person);
+      const steve = collection.add<Person>({ firstName: 'Steve', spouse: 1 }, Person);
+      const jane = collection.add<Person>({ firstName: 'Jane', spouse: 1 }, Person);
+      const fido = collection.add<Toy>({ name: 'Fido', owners: [steve.id, jane.id] }, Toy);
+
+      expect(fido.owners.length).toBe(2);
+      expect(fido.owners[0]).toBe(steve);
+      expect(fido.owners[1]).toBe(jane);
+      expect(steve.toys.length).toBe(1);
+      expect(jane.toys.length).toBe(1);
+      expect(steve.toys[0].name).toBe(fido.name);
+      expect(jane.toys[0].name).toBe(fido.name);
+    });
+
+    it('should be use ids for indirect references before references existed', () => {
+      class MyCollection extends Collection {
+        static types = [Person, Pet, Toy];
+      }
+
+      const collection = new MyCollection();
+
+      collection.add<Person>({ firstName: 'Jane', id: 1 }, Person);
+      const fido = collection.add<Toy>({ name: 'Fido', owners: [1, 2] }, Toy);
+      const steve = collection.add<Person>({ firstName: 'Steve', spouse: 2, id: 1 }, Person);
+      const jane = collection.add<Person>({ firstName: 'Jane', spouse: 1, id: 2 }, Person);
+
+      expect(fido.owners.length).toBe(2);
+      expect(fido.owners[0]).toBe(steve);
+      expect(fido.owners[1]).toBe(jane);
+      expect(steve.toys.length).toBe(1);
+      expect(jane.toys.length).toBe(1);
+      expect(steve.toys[0].name).toBe(fido.name);
+      expect(jane.toys[0].name).toBe(fido.name);
+    });
+
+    it('should be use modelRefs for indirect references', () => {
+      class MyCollection extends Collection {
+        static types = [Person, Pet, Toy];
+      }
+
+      const collection = new MyCollection();
+
+      collection.add<Person>({ firstName: 'Jane', id: 1 }, Person);
+      const steve = collection.add<Person>({ firstName: 'Steve', spouse: 1 }, Person);
+      const jane = collection.add<Person>({ firstName: 'Jane', spouse: 1 }, Person);
+      const fido = collection.add<Toy>(
+        {
+          name: 'Fido',
+          owners: [
+            { type: 'person', id: steve.id },
+            { type: 'person', id: jane.id },
+          ],
+        },
+        Toy,
+      );
+
+      expect(fido.owners.length).toBe(2);
+      expect(fido.owners[0]).toBe(steve);
+      expect(fido.owners[1]).toBe(jane);
+      expect(steve.toys.length).toBe(1);
+      expect(jane.toys.length).toBe(1);
+      expect(steve.toys[0].name).toBe(fido.name);
+      expect(jane.toys[0].name).toBe(fido.name);
     });
   });
 });


### PR DESCRIPTION
When updating the model, the `updateModel` method updates the indirect reference with the `undefined` value, causing an exception