### PR TITLE
Fix can`t update the properties of a model that has an indirect reference

### DIFF
--- a/packages/datx/src/helpers/collection.ts
+++ b/packages/datx/src/helpers/collection.ts
@@ -45,7 +45,11 @@ export function upsertModel(
     const parsedData = {};
 
     keys.forEach((key: string) => {
-      parsedData[key] = modelMapParse(TypeModel, data, key);
+      const isBackRefKey = Boolean(fields[key]?.referenceDef?.property);
+      const result = modelMapParse(TypeModel, data, key);
+      if (!(isBackRefKey && result === undefined && !(key in data))) {
+        parsedData[key] = result;
+      }
     });
     return updateModel(existingModel, parsedData);
   }

--- a/packages/datx/src/helpers/model/init.ts
+++ b/packages/datx/src/helpers/model/init.ts
@@ -28,7 +28,7 @@ import { IType } from '../../interfaces/IType';
 type ModelFieldDefinitions = Record<string, IFieldDefinition>;
 
 export function getModelRefType(
-  model: ParsedRefModel,
+  model: ParsedRefModel | IType,
   data: any,
   parentModel: PureModel,
   key: string,
@@ -112,6 +112,7 @@ export function initModelRef<T extends PureModel>(
     let value: TRefValue = fieldDef.referenceDef.type === ReferenceType.TO_MANY ? [] : null;
 
     if (initialVal !== null && initialVal !== undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       value = getRefValue(initialVal, collection!, fieldDef, model, key);
     }
 
@@ -126,6 +127,7 @@ export function initModelRef<T extends PureModel>(
       () => getRef(model, key),
       (newValue: TRefValue) => {
         updateSingleAction(model, key, newValue);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         updateRef(model, key, getRefValue(newValue, collection!, fieldDef, model, key));
       },
     );

--- a/packages/datx/test/collection.ts
+++ b/packages/datx/test/collection.ts
@@ -578,8 +578,147 @@ describe('Collection', () => {
       );
       expect(store.findAll(Foo).length).toBe(1);
       const foo = store.findOne<Foo>(Foo, '0');
-      expect(foo!.name).toBe('foo1');
-      expect(foo!.children).toEqual([]);
+      expect(foo?.name).toBe('foo1');
+      expect(foo?.children).toEqual([]);
+    });
+  });
+
+  describe('Indirect references', () => {
+    class Person extends Model {
+      static type = 'person';
+
+      @Attribute({ isIdentifier: true }) id!: number;
+
+      @Attribute() public firstName!: string;
+      @Attribute() public lastName!: string;
+
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      @Attribute({ toMany: () => Pet, referenceProperty: 'owner' }) pets!: Array<Pet>;
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      @Attribute({ toMany: () => Toy, referenceProperty: 'owners' }) toys!: Array<Toy>;
+    }
+
+    class Pet extends Model {
+      static type = 'pet';
+
+      @Attribute() public name!: string;
+      @Attribute({ toOne: () => Person }) public owner!: Person;
+    }
+
+    class Toy extends Model {
+      static type = 'toy';
+
+      @Attribute() public name!: string;
+      @Attribute({ toMany: () => Person }) public owners!: Person[];
+    }
+
+    it('should be use model for indirect references', () => {
+      class MyCollection extends Collection {
+        static types = [Person, Pet];
+      }
+
+      const collection = new MyCollection();
+
+      collection.add<Person>({ firstName: 'Jane', id: 1 }, Person);
+      const steve = collection.add<Person>({ firstName: 'Steve', spouse: 1 }, Person);
+      const fido = collection.add<Pet>({ name: 'Fido', owner: steve }, Pet);
+
+      expect(fido.owner).toBe(steve);
+      expect(steve.pets.length).toBe(1);
+      expect(steve.pets[0].name).toBe(fido.name);
+    });
+
+    it('should be use id for indirect references', () => {
+      class MyCollection extends Collection {
+        static types = [Person, Pet];
+      }
+
+      const collection = new MyCollection();
+
+      collection.add<Person>({ firstName: 'Jane', id: 1 }, Person);
+      const steve = collection.add<Person>({ firstName: 'Steve', spouse: 1 }, Person);
+      const fido = collection.add<Pet>({ name: 'Fido', owner: steve.id }, Pet);
+      const wufi = collection.add<Pet>({ name: 'wufi', owner: steve.id }, Pet);
+
+      expect(fido.owner).toBe(steve);
+      expect(steve.pets.length).toBe(2);
+      expect(steve.pets[0].name).toBe(fido.name);
+      expect(steve.pets[1].name).toBe(wufi.name);
+      collection.removeOne(wufi);
+      expect(steve.pets.length).toBe(1);
+      expect(steve.pets[0].name).toBe(fido.name);
+    });
+
+    it('should be use ids for indirect references', () => {
+      class MyCollection extends Collection {
+        static types = [Person, Pet, Toy];
+      }
+
+      const collection = new MyCollection();
+
+      collection.add<Person>({ firstName: 'Jane', id: 1 }, Person);
+      const steve = collection.add<Person>({ firstName: 'Steve', spouse: 1 }, Person);
+      const jane = collection.add<Person>({ firstName: 'Jane', spouse: 1 }, Person);
+      const fido = collection.add<Toy>({ name: 'Fido', owners: [steve.id, jane.id] }, Toy);
+
+      expect(fido.owners.length).toBe(2);
+      expect(fido.owners[0]).toBe(steve);
+      expect(fido.owners[1]).toBe(jane);
+      expect(steve.toys.length).toBe(1);
+      expect(jane.toys.length).toBe(1);
+      expect(steve.toys[0].name).toBe(fido.name);
+      expect(jane.toys[0].name).toBe(fido.name);
+    });
+
+    it('should be use ids for indirect references before references existed', () => {
+      class MyCollection extends Collection {
+        static types = [Person, Pet, Toy];
+      }
+
+      const collection = new MyCollection();
+
+      collection.add<Person>({ firstName: 'Jane', id: 1 }, Person);
+      const fido = collection.add<Toy>({ name: 'Fido', owners: [1, 2] }, Toy);
+      const steve = collection.add<Person>({ firstName: 'Steve', spouse: 2, id: 1 }, Person);
+      const jane = collection.add<Person>({ firstName: 'Jane', spouse: 1, id: 2 }, Person);
+
+      expect(fido.owners.length).toBe(2);
+      expect(fido.owners[0]).toBe(steve);
+      expect(fido.owners[1]).toBe(jane);
+      expect(steve.toys.length).toBe(1);
+      expect(jane.toys.length).toBe(1);
+      expect(steve.toys[0].name).toBe(fido.name);
+      expect(jane.toys[0].name).toBe(fido.name);
+    });
+
+    it('should be use modelRefs for indirect references', () => {
+      class MyCollection extends Collection {
+        static types = [Person, Pet, Toy];
+      }
+
+      const collection = new MyCollection();
+
+      collection.add<Person>({ firstName: 'Jane', id: 1 }, Person);
+      const steve = collection.add<Person>({ firstName: 'Steve', spouse: 1 }, Person);
+      const jane = collection.add<Person>({ firstName: 'Jane', spouse: 1 }, Person);
+      const fido = collection.add<Toy>(
+        {
+          name: 'Fido',
+          owners: [
+            { type: 'person', id: steve.id },
+            { type: 'person', id: jane.id },
+          ],
+        },
+        Toy,
+      );
+
+      expect(fido.owners.length).toBe(2);
+      expect(fido.owners[0]).toBe(steve);
+      expect(fido.owners[1]).toBe(jane);
+      expect(steve.toys.length).toBe(1);
+      expect(jane.toys.length).toBe(1);
+      expect(steve.toys[0].name).toBe(fido.name);
+      expect(jane.toys[0].name).toBe(fido.name);
     });
   });
 });


### PR DESCRIPTION
 

Before the update, upsertModel will recalculate all properties of the model with updated data. At this time, if the indirectly referenced value has a value, the indirectly referenced reference will be undefined(even if the indirectly referenced value does not exist in data), resulting in the use of undefined to update the indirectly referenced value, throw an exception.