### PR TITLE
Fix `isArrayLike` return type

### DIFF
--- a/packages/datx-utils/src/helpers.ts
+++ b/packages/datx-utils/src/helpers.ts
@@ -1,4 +1,4 @@
-import { extendObservable, observable, set, isObservableArray } from 'mobx';
+import { extendObservable, observable, set, isObservableArray, IObservableArray } from 'mobx';
 
 import { DATX_META } from './consts';
 
@@ -17,7 +17,7 @@ export const makeObservable =
     // noop by default
   });
 
-export function isArrayLike(value: any): boolean {
+export function isArrayLike(value: any): value is Array<any> | IObservableArray<any> {
   return Array.isArray(value) || isObservableArray(value);
 }
 


### PR DESCRIPTION
Makes it unnecessary to force a type to be specified in branch judgment
e.g.
   if(isArrayLike(value)) {
     // value is T[]
     value.forEach(...)
   }