### PR TITLE
Fix network mixin docs

### DIFF
--- a/docs/mixins/network-mixin.md
+++ b/docs/mixins/network-mixin.md
@@ -27,6 +27,6 @@ The lib makes use of the following features that are not yet available everywher
 - [operators](../network/operators)
 - [caching](../network/caching)
 - [interceptors](../network/interceptors)
-- [parse/serialize](../network/parse-serialize)
+- [parser](../network/operators#parser) / [serializer](../network/operators#serializer)
 - [fetching](../network/fetching)
 - [TypeScript Interfaces](../network/typescript-interfaces)

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -5,6 +5,12 @@
     "previous": "Previous",
     "tagline": "A mobx data store",
     "docs": {
+      "api-reference/attribute": {
+        "title": "Attribute"
+      },
+      "api-reference/bucket": {
+        "title": "Bucket"
+      },
       "api-reference/collection": {
         "title": "Collection"
       },
@@ -17,9 +23,6 @@
       "api-reference/model": {
         "title": "Model"
       },
-      "api-reference/prop": {
-        "title": "Prop"
-      },
       "api-reference/pure-model": {
         "title": "Pure Model"
       },
@@ -31,6 +34,9 @@
       },
       "examples/adding-models": {
         "title": "Adding models"
+      },
+      "examples/angular-setup": {
+        "title": "Angular JSON:API setup"
       },
       "examples/basic-setup": {
         "title": "Basic setup"
@@ -59,6 +65,12 @@
       "getting-started/using-the-collection": {
         "title": "Using the collection"
       },
+      "jsonapi-angular/base-fetch": {
+        "title": "Angular JSON:API baseFetch"
+      },
+      "jsonapi-angular/mixin": {
+        "title": "Angular JSON:API mixin"
+      },
       "jsonapi/jsonapi-basic-configuration": {
         "title": "Basic configuration"
       },
@@ -69,7 +81,7 @@
         "title": "Config"
       },
       "jsonapi/jsonapi-getting-started": {
-        "title": "Getting started with JSON Api"
+        "title": "Getting started with JSON API"
       },
       "jsonapi/jsonapi-model": {
         "title": "Model"
@@ -95,23 +107,26 @@
       "jsonapi/jsonapi-view": {
         "title": "View"
       },
-      "migration-guide/compat-collection": {
-        "title": "CompatCollection"
+      "migration-guide/breaking-changes": {
+        "title": "Breaking changes since v1"
       },
-      "migration-guide/compat-model": {
-        "title": "CompatModel"
+      "migration-guide/deprecations": {
+        "title": "Deprecations in v2"
       },
-      "migration-guide/mobx-collection-store": {
-        "title": "Mobx collection store"
+      "migration-guide/from-v1": {
+        "title": "Migration from v1"
       },
-      "migration-guide/mobx-jsonapi-store": {
-        "title": "Mobx jsonapi store"
+      "migration-guide/whats-new": {
+        "title": "What's new"
       },
       "mixins/building-your-own-mixin": {
         "title": "Build your own mixin"
       },
       "mixins/jsonapi-mixin": {
         "title": "JSONAPI Mixin"
+      },
+      "mixins/network-mixin": {
+        "title": "Network Mixin"
       },
       "mixins/what-are-mixins": {
         "title": "What are mixins"
@@ -124,6 +139,30 @@
       },
       "mixins/with-patches": {
         "title": "withPatches"
+      },
+      "network/base-request": {
+        "title": "BaseRequest"
+      },
+      "network/caching": {
+        "title": "Caching"
+      },
+      "network/fetching": {
+        "title": "Fetching"
+      },
+      "network/getting-started": {
+        "title": "Getting started with DatX Network"
+      },
+      "network/interceptors": {
+        "title": "Interceptors"
+      },
+      "network/operators": {
+        "title": "Operators"
+      },
+      "network/response": {
+        "title": "Response"
+      },
+      "network/typescript-interfaces": {
+        "title": "TypeScript interfaces"
       },
       "troubleshooting/known-issues": {
         "title": "Known issues"
@@ -244,6 +283,147 @@
       },
       "version-1.0.0/troubleshooting/version-1.0.0-known-issues": {
         "title": "Known issues"
+      },
+      "version-2.0.0/api-reference/version-2.0.0-attribute": {
+        "title": "Attribute"
+      },
+      "version-2.0.0/api-reference/version-2.0.0-bucket": {
+        "title": "Bucket"
+      },
+      "version-2.0.0/api-reference/version-2.0.0-collection": {
+        "title": "Collection"
+      },
+      "version-2.0.0/api-reference/version-2.0.0-lib-utils": {
+        "title": "Lib utils"
+      },
+      "version-2.0.0/api-reference/version-2.0.0-model": {
+        "title": "Model"
+      },
+      "version-2.0.0/api-reference/version-2.0.0-typescript-interfaces": {
+        "title": "Typescript interfaces"
+      },
+      "version-2.0.0/examples/version-2.0.0-adding-models": {
+        "title": "Adding models"
+      },
+      "version-2.0.0/examples/version-2.0.0-angular-setup": {
+        "title": "Angular JSON:API setup"
+      },
+      "version-2.0.0/examples/version-2.0.0-basic-setup": {
+        "title": "Basic setup"
+      },
+      "version-2.0.0/examples/version-2.0.0-react-setup": {
+        "title": "React setup"
+      },
+      "version-2.0.0/getting-started/version-2.0.0-configuring-the-collection": {
+        "title": "Configuring the collection"
+      },
+      "version-2.0.0/getting-started/version-2.0.0-defining-models": {
+        "title": "Defining models"
+      },
+      "version-2.0.0/getting-started/version-2.0.0-installation": {
+        "title": "Installation"
+      },
+      "version-2.0.0/getting-started/version-2.0.0-persisting-data-locally": {
+        "title": "Persisting data locally"
+      },
+      "version-2.0.0/getting-started/version-2.0.0-references": {
+        "title": "References"
+      },
+      "version-2.0.0/getting-started/version-2.0.0-using-the-collection": {
+        "title": "Using the collection"
+      },
+      "version-2.0.0/jsonapi-angular/version-2.0.0-base-fetch": {
+        "title": "Angular JSON:API baseFetch"
+      },
+      "version-2.0.0/jsonapi-angular/version-2.0.0-mixin": {
+        "title": "Angular JSON:API mixin"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-basic-configuration": {
+        "title": "Basic configuration"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-collection": {
+        "title": "Collection"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-config": {
+        "title": "Config"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-getting-started": {
+        "title": "Getting started with JSON API"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-model": {
+        "title": "Model"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-network-configuration": {
+        "title": "Network configuration"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-network-usage": {
+        "title": "Network usage"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-response": {
+        "title": "Response"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-spec-compliance": {
+        "title": "Spec compliance"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-typescript-interfaces": {
+        "title": "Typescript interfaces"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-utils": {
+        "title": "Utils"
+      },
+      "version-2.0.0/jsonapi/version-2.0.0-jsonapi-view": {
+        "title": "View"
+      },
+      "version-2.0.0/migration-guide/version-2.0.0-breaking-changes": {
+        "title": "Breaking changes since v1"
+      },
+      "version-2.0.0/migration-guide/version-2.0.0-deprecations": {
+        "title": "Deprecations in v2"
+      },
+      "version-2.0.0/migration-guide/version-2.0.0-from-v1": {
+        "title": "Migration from v1"
+      },
+      "version-2.0.0/migration-guide/version-2.0.0-whats-new": {
+        "title": "What's new"
+      },
+      "version-2.0.0/mixins/version-2.0.0-building-your-own-mixin": {
+        "title": "Build your own mixin"
+      },
+      "version-2.0.0/mixins/version-2.0.0-network-mixin": {
+        "title": "Network Mixin"
+      },
+      "version-2.0.0/mixins/version-2.0.0-with-actions": {
+        "title": "withActions"
+      },
+      "version-2.0.0/mixins/version-2.0.0-with-meta": {
+        "title": "withMeta"
+      },
+      "version-2.0.0/network/version-2.0.0-base-request": {
+        "title": "BaseRequest"
+      },
+      "version-2.0.0/network/version-2.0.0-caching": {
+        "title": "Caching"
+      },
+      "version-2.0.0/network/version-2.0.0-fetching": {
+        "title": "Fetching"
+      },
+      "version-2.0.0/network/version-2.0.0-getting-started": {
+        "title": "Getting started with DatX Network"
+      },
+      "version-2.0.0/network/version-2.0.0-interceptors": {
+        "title": "Interceptors"
+      },
+      "version-2.0.0/network/version-2.0.0-operators": {
+        "title": "Operators"
+      },
+      "version-2.0.0/network/version-2.0.0-response": {
+        "title": "Response"
+      },
+      "version-2.0.0/network/version-2.0.0-typescript-interfaces": {
+        "title": "TypeScript interfaces"
+      },
+      "version-2.0.0/troubleshooting/version-2.0.0-known-issues": {
+        "title": "Known issues"
       }
     },
     "links": {
@@ -255,7 +435,9 @@
       "Getting started": "Getting started",
       "Mixins": "Mixins",
       "API Reference": "API Reference",
+      "Network": "Network",
       "JSON API": "JSON API",
+      "JSON API Angular": "JSON API Angular",
       "Migration guide": "Migration guide",
       "Troubleshooting": "Troubleshooting",
       "Setup": "Setup",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -27,6 +27,16 @@
       "api-reference/lib-utils",
       "api-reference/typescript-interfaces"
     ],
+    "Network": [
+      "network/getting-started",
+      "network/base-request",
+      "network/caching",
+      "network/fetching",
+      "network/interceptors",
+      "network/operators",
+      "network/response",
+      "network/typescript-interfaces"
+    ],
     "JSON API": [
       "jsonapi/jsonapi-getting-started",
       "jsonapi/jsonapi-basic-configuration",
@@ -41,10 +51,7 @@
       "jsonapi/jsonapi-utils",
       "jsonapi/jsonapi-typescript-interfaces"
     ],
-    "JSON API Angular": [
-      "jsonapi-angular/mixin",
-      "jsonapi-angular/base-fetch"
-    ],
+    "JSON API Angular": ["jsonapi-angular/mixin", "jsonapi-angular/base-fetch"],
     "Migration guide": [
       "migration-guide/breaking-changes",
       "migration-guide/deprecations",
@@ -54,7 +61,12 @@
     "Troubleshooting": ["troubleshooting/known-issues"]
   },
   "examples": {
-    "Setup": ["examples/basic-setup", "examples/react-setup", "examples/nextjs-setup", "examples/angular-setup"],
+    "Setup": [
+      "examples/basic-setup",
+      "examples/react-setup",
+      "examples/nextjs-setup",
+      "examples/angular-setup"
+    ],
     "Collection": ["examples/adding-models"]
   }
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -13,6 +13,7 @@
       "mixins/with-actions",
       "mixins/with-meta",
       "mixins/with-patches",
+      "mixins/network-mixin",
       "mixins/jsonapi-mixin",
       "mixins/building-your-own-mixin"
     ],

--- a/website/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-2.0.0-sidebars.json
@@ -27,6 +27,16 @@
       "version-2.0.0-api-reference/lib-utils",
       "version-2.0.0-api-reference/typescript-interfaces"
     ],
+    "Network": [
+      "version-2.0.0-network/getting-started",
+      "version-2.0.0-network/base-request",
+      "version-2.0.0-network/caching",
+      "version-2.0.0-network/fetching",
+      "version-2.0.0-network/interceptors",
+      "version-2.0.0-network/operators",
+      "version-2.0.0-network/response",
+      "version-2.0.0-network/typescript-interfaces"
+    ],
     "JSON API": [
       "version-2.0.0-jsonapi/jsonapi-getting-started",
       "version-2.0.0-jsonapi/jsonapi-basic-configuration",
@@ -51,9 +61,7 @@
       "version-2.0.0-migration-guide/whats-new",
       "version-2.0.0-migration-guide/from-v1"
     ],
-    "Troubleshooting": [
-      "version-2.0.0-troubleshooting/known-issues"
-    ]
+    "Troubleshooting": ["version-2.0.0-troubleshooting/known-issues"]
   },
   "version-2.0.0-examples": {
     "Setup": [
@@ -62,8 +70,6 @@
       "version-2.0.0-examples/nextjs-setup",
       "version-2.0.0-examples/angular-setup"
     ],
-    "Collection": [
-      "version-2.0.0-examples/adding-models"
-    ]
+    "Collection": ["version-2.0.0-examples/adding-models"]
   }
 }

--- a/website/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-2.0.0-sidebars.json
@@ -13,6 +13,7 @@
       "version-2.0.0-mixins/with-actions",
       "version-2.0.0-mixins/with-meta",
       "version-2.0.0-mixins/with-patches",
+      "version-2.0.0-mixins/network-mixin",
       "version-2.0.0-mixins/jsonapi-mixin",
       "version-2.0.0-mixins/building-your-own-mixin"
     ],


### PR DESCRIPTION
1. Currently, Network documentation is not defined in sidebars.json and thus it is not available on the docs page.
2. Network mixin link was not present in the mixin sidebar
3. parser / serializer links were not pointing to the operators docs

