### PR TITLE
Add getAll method on collection and view

### DIFF
--- a/docs/jsonapi/jsonapi-collection.md
+++ b/docs/jsonapi/jsonapi-collection.md
@@ -45,6 +45,27 @@ The options can be used to send additional parameters to the server.
 
 If an error happens, the function will reject with the [`Response`](jsonapi-response) object with the `error` property set.
 
+## getAll
+
+```typescript
+getAll<T extends IJsonapiModel = IJsonapiModel>(type: IType | IModelConstructor<T>, options?: IRequestOptions): Promise<IGetAllResponse<T>>
+```
+
+Fetch all records of the given type from the server.
+
+Unlike other collection methods that return a `Response` instance, `getAll` returns an object that contains:
+
+- data: array of all models
+- responses: array of all responses that came from the server
+- latestResponse: `Response` instance for easy acces to all `Response` properties
+
+See [`IGetAllResponse`](jsonapi-typescript-interfaces#igetallresponse) interface for detailed info.
+
+The options can be used to send additional parameters to the server.
+
+If an error happens, the function will reject with the [`Response`](jsonapi-response) object with the `error` property set.
+
+
 ## request
 
 ```typescript

--- a/docs/jsonapi/jsonapi-collection.md
+++ b/docs/jsonapi/jsonapi-collection.md
@@ -57,7 +57,7 @@ Unlike other collection methods that return a `Response` instance, `getAll` retu
 
 - data: array of all models
 - responses: array of all responses that came from the server
-- latestResponse: `Response` instance for easy acces to all `Response` properties
+- lastResponse: `Response` instance for easy acces to all `Response` properties
 
 See [`IGetAllResponse`](jsonapi-typescript-interfaces#igetallresponse) interface for detailed info.
 

--- a/docs/jsonapi/jsonapi-collection.md
+++ b/docs/jsonapi/jsonapi-collection.md
@@ -48,10 +48,11 @@ If an error happens, the function will reject with the [`Response`](jsonapi-resp
 ## getAll
 
 ```typescript
-getAll<T extends IJsonapiModel = IJsonapiModel>(type: IType | IModelConstructor<T>, options?: IRequestOptions): Promise<IGetAllResponse<T>>
+getAll<T extends IJsonapiModel = IJsonapiModel>(type: IType | IModelConstructor<T>, options?: IRequestOptions, maxRequests?: number = 50): Promise<IGetAllResponse<T>>
 ```
 
-Fetch all records of the given type from the server.
+Fetches all records within the request limit of the given type from the server. 
+Generally you don't want to use this function if you are trying to load **a lot** of pages at once since it could lead to the huge response time.
 
 Unlike other collection methods that return a `Response` instance, `getAll` returns an object that contains:
 

--- a/docs/jsonapi/jsonapi-typescript-interfaces.md
+++ b/docs/jsonapi/jsonapi-typescript-interfaces.md
@@ -73,7 +73,7 @@ interface IRequestOptions {
 Interface defining return type for `getAll` method on [collections](jsonapi-collection#getall) and [views](jsonapi-view#getall)
 
 ```typescript
-interface IGetAllResponse<T extends JsonapiModel = JsonapiModel> {
+interface IGetAllResponse<T extends IJsonapiModel = IJsonapiModel> {
   data: Array<T>;
   responses: Array<Response>;
   lastResponse: Response;

--- a/docs/jsonapi/jsonapi-typescript-interfaces.md
+++ b/docs/jsonapi/jsonapi-typescript-interfaces.md
@@ -75,7 +75,7 @@ Interface defining return type for `getAll` method on [collections](jsonapi-coll
 ```typescript
 interface IGetAllResponse<T extends IJsonapiModel = IJsonapiModel> {
   data: Array<T>;
-  responses: Array<Response>;
-  lastResponse: Response;
+  responses: Array<Response<T>>;
+  lastResponse: Response<T>;
 }
 ```

--- a/docs/jsonapi/jsonapi-typescript-interfaces.md
+++ b/docs/jsonapi/jsonapi-typescript-interfaces.md
@@ -67,3 +67,15 @@ interface IRequestOptions {
   };
 }
 ```
+
+## IGetAllResponse
+
+Interface defining return type for `getAll` method on [collections](jsonapi-collection#getall) and [views](jsonapi-view#getall)
+
+```typescript
+interface IGetAllResponse<T extends JsonapiModel = JsonapiModel> {
+  data: Array<T>;
+  responses: Array<Response>;
+  lastResponse: Response;
+}
+```

--- a/docs/jsonapi/jsonapi-view.md
+++ b/docs/jsonapi/jsonapi-view.md
@@ -49,7 +49,7 @@ Unlike other view methods that return a `Response` instance, `getAll` returns an
 
 - data: array of all models
 - responses: array of all responses that came from the server
-- latestResponse: `Response` instance for easy acces to all `Response` properties
+- lastResponse: `Response` instance for easy acces to all `Response` properties
 
 See [`IGetAllResponse`](jsonapi-typescript-interfaces#igetallresponse) interface for detailed info.
 

--- a/docs/jsonapi/jsonapi-view.md
+++ b/docs/jsonapi/jsonapi-view.md
@@ -40,10 +40,11 @@ If an error happens, the function will reject with the [`Response`](jsonapi-resp
 ## getAll
 
 ```typescript
-getAll<T extends IJsonapiModel = IJsonapiModel>(type: IType | IModelConstructor<T>, options?: IRequestOptions): Promise<IGetAllResponse<T>>
+getAll<T extends IJsonapiModel = IJsonapiModel>(type: IType | IModelConstructor<T>, options?: IRequestOptions, maxRequests?: number = 50): Promise<IGetAllResponse<T>>
 ```
 
-Fetches all records of the given type from the server and saves it into the view.
+Fetches all records within the request limit of the given type from the server and saves it into the view. 
+Generally you don't want to use this function if you are trying to load **a lot** of pages at once since it could lead to the huge response time.
 
 Unlike other view methods that return a `Response` instance, `getAll` returns an object that contains:
 

--- a/docs/jsonapi/jsonapi-view.md
+++ b/docs/jsonapi/jsonapi-view.md
@@ -36,3 +36,23 @@ Fetch multiple models of the view type from the server. This will either be all 
 The options can be used to send additional parameters to the server.
 
 If an error happens, the function will reject with the [`Response`](jsonapi-response) object with the `error` property set.
+
+## getAll
+
+```typescript
+getAll<T extends IJsonapiModel = IjsonapiModel>(type: IType | IModelConstructor<T>, options?: IRequestOptions): Promise<IGetAllResponse<T>>
+```
+
+Fetches all records of the given type from the server and saves it into the view.
+
+Unlike other view methods that return a `Response` instance, `getAll` returns an object that contains:
+
+- data: array of all models
+- responses: array of all responses that came from the server
+- latestResponse: `Response` instance for easy acces to all `Response` properties
+
+See [`IGetAllResponse`](jsonapi-typescript-interfaces#igetallresponse) interface for detailed info.
+
+The options can be used to send additional parameters to the server.
+
+If an error happens, the function will reject with the [`Response`](jsonapi-response) object with the `error` property set.

--- a/docs/jsonapi/jsonapi-view.md
+++ b/docs/jsonapi/jsonapi-view.md
@@ -40,7 +40,7 @@ If an error happens, the function will reject with the [`Response`](jsonapi-resp
 ## getAll
 
 ```typescript
-getAll<T extends IJsonapiModel = IjsonapiModel>(type: IType | IModelConstructor<T>, options?: IRequestOptions): Promise<IGetAllResponse<T>>
+getAll<T extends IJsonapiModel = IJsonapiModel>(type: IType | IModelConstructor<T>, options?: IRequestOptions): Promise<IGetAllResponse<T>>
 ```
 
 Fetches all records of the given type from the server and saves it into the view.

--- a/packages/datx-jsonapi/src/decorateCollection.ts
+++ b/packages/datx-jsonapi/src/decorateCollection.ts
@@ -181,15 +181,8 @@ export function decorateCollection(
       if (maxRequests < 1) {
         throw Error('Please enter a meaningful amount of max requests.');
       }
-      const response = await this.getMany(type, options);
 
-      if (maxRequests === 1) {
-        return {
-          data: response.data as Array<T>,
-          responses: [response],
-          lastResponse: response,
-        };
-      }
+      const response = await this.getMany(type, options);
 
       return getAllResponses(response, maxRequests);
     }

--- a/packages/datx-jsonapi/src/decorateCollection.ts
+++ b/packages/datx-jsonapi/src/decorateCollection.ts
@@ -25,7 +25,7 @@ import {
 import { GenericModel } from './GenericModel';
 import { flattenModel, removeModel } from './helpers/model';
 import { buildUrl, prepareQuery } from './helpers/url';
-import { getModelClassRefs, isBrowser } from './helpers/utils';
+import { getAllResponses, getModelClassRefs, isBrowser } from './helpers/utils';
 import { IHeaders } from './interfaces/IHeaders';
 import { IJsonapiCollection } from './interfaces/IJsonapiCollection';
 import { IJsonapiModel } from './interfaces/IJsonapiModel';
@@ -177,27 +177,9 @@ export function decorateCollection(
       type: IType | IModelConstructor<T>,
       options?: IRequestOptions,
     ): Promise<IGetAllResponse<T>> {
-      let response = await this.getMany(type, options);
+      const response = await this.getMany(type, options);
 
-      const data: Array<T> = [];
-      const responses: Array<Response<T>> = [];
-      let lastResponse = response;
-
-      data.push(...(response.data as Array<T>));
-      responses.push(response);
-
-      while (response.next) {
-        response = await response.next();
-        responses.push(response);
-        data.push(...(response.data as Array<T>));
-        lastResponse = response;
-      }
-
-      return {
-        data,
-        responses,
-        lastResponse,
-      };
+      return getAllResponses(response);
     }
 
     public request<T extends IJsonapiModel = IJsonapiModel>(

--- a/packages/datx-jsonapi/src/decorateCollection.ts
+++ b/packages/datx-jsonapi/src/decorateCollection.ts
@@ -181,7 +181,7 @@ export function decorateCollection(
 
       const data: Array<T> = [];
       const responses: Array<Response<T>> = [];
-      let lastMeta = response.meta;
+      let lastResponse = response;
 
       data.push(...(response.data as Array<T>));
       responses.push(response);
@@ -190,13 +190,13 @@ export function decorateCollection(
         response = await response.next();
         responses.push(response);
         data.push(...(response.data as Array<T>));
-        lastMeta = response.meta;
+        lastResponse = response;
       }
 
       return {
         data,
         responses,
-        lastMeta,
+        lastResponse,
       };
     }
 

--- a/packages/datx-jsonapi/src/decorateCollection.ts
+++ b/packages/datx-jsonapi/src/decorateCollection.ts
@@ -176,10 +176,22 @@ export function decorateCollection(
     public async getAll<T extends IJsonapiModel = IJsonapiModel>(
       type: IType | IModelConstructor<T>,
       options?: IRequestOptions,
+      maxRequests = 50,
     ): Promise<IGetAllResponse<T>> {
+      if (maxRequests < 1) {
+        throw Error('Please enter a meaningful amount of max requests.');
+      }
       const response = await this.getMany(type, options);
 
-      return getAllResponses(response);
+      if (maxRequests === 1) {
+        return {
+          data: response.data as Array<T>,
+          responses: [response],
+          lastResponse: response,
+        };
+      }
+
+      return getAllResponses(response, maxRequests);
     }
 
     public request<T extends IJsonapiModel = IJsonapiModel>(

--- a/packages/datx-jsonapi/src/decorateCollection.ts
+++ b/packages/datx-jsonapi/src/decorateCollection.ts
@@ -34,6 +34,7 @@ import { IDefinition, IRecord, IRelationship, IRequest, IResponse } from './inte
 import { libFetch, read } from './NetworkUtils';
 import { Response } from './Response';
 import { CachingStrategy } from '@datx/network';
+import { IGetAllResponse } from './interfaces/IGetAllResponse';
 
 type TSerialisedStore = IRawCollection & { cache?: Array<Omit<ICacheInternal, 'collection'>> };
 
@@ -175,15 +176,8 @@ export function decorateCollection(
     public async getAll<T extends IJsonapiModel = IJsonapiModel>(
       type: IType | IModelConstructor<T>,
       options?: IRequestOptions,
-    ) {
-      const modelType = getModelType(type);
-      const query = this.__prepareQuery(modelType, undefined, undefined, options);
-      const reqOptions = options || {};
-
-      reqOptions.networkConfig = reqOptions.networkConfig || {};
-      reqOptions.networkConfig.headers = query.headers;
-
-      let response = await read<T>(query.url, this, reqOptions).then(handleErrors);
+    ): Promise<IGetAllResponse<T>> {
+      let response = await this.getMany(type, options);
 
       const data: Array<T> = [];
       const responses: Array<Response<T>> = [];

--- a/packages/datx-jsonapi/src/decorateView.ts
+++ b/packages/datx-jsonapi/src/decorateView.ts
@@ -6,6 +6,7 @@ import {
   PureModel,
   View,
 } from '@datx/core';
+import { getAllResponses } from './helpers/utils';
 import { IGetAllResponse } from './interfaces/IGetAllResponse';
 
 import { IJsonapiCollection } from './interfaces/IJsonapiCollection';
@@ -68,27 +69,9 @@ export function decorateView<U>(
     }
 
     public async getAll(options?: IRequestOptions): Promise<IGetAllResponse<M>> {
-      let response = await this.getMany(options);
+      const response = await this.getMany(options);
 
-      const data: Array<M> = [];
-      const responses: Array<Response<M>> = [];
-      let lastResponse = response;
-
-      data.push(...(response.data as Array<M>));
-      responses.push(response);
-
-      while (response.next) {
-        response = await response.next();
-        responses.push(response);
-        data.push(...(response.data as Array<M>));
-        lastResponse = response;
-      }
-
-      return {
-        data,
-        responses,
-        lastResponse,
-      };
+      return getAllResponses(response);
     }
 
     protected __addFromResponse(response: Response<M>): Response<M> {

--- a/packages/datx-jsonapi/src/decorateView.ts
+++ b/packages/datx-jsonapi/src/decorateView.ts
@@ -72,7 +72,7 @@ export function decorateView<U>(
 
       const data: Array<M> = [];
       const responses: Array<Response<M>> = [];
-      let lastMeta = response.meta;
+      let lastResponse = response;
 
       data.push(...(response.data as Array<M>));
       responses.push(response);
@@ -81,13 +81,13 @@ export function decorateView<U>(
         response = await response.next();
         responses.push(response);
         data.push(...(response.data as Array<M>));
-        lastMeta = response.meta;
+        lastResponse = response;
       }
 
       return {
         data,
         responses,
-        lastMeta,
+        lastResponse,
       };
     }
 

--- a/packages/datx-jsonapi/src/decorateView.ts
+++ b/packages/datx-jsonapi/src/decorateView.ts
@@ -68,10 +68,21 @@ export function decorateView<U>(
         .then(this.__addFromResponse.bind(this));
     }
 
-    public async getAll(options?: IRequestOptions): Promise<IGetAllResponse<M>> {
+    public async getAll(options?: IRequestOptions, maxRequests = 50): Promise<IGetAllResponse<M>> {
+      if (maxRequests < 1) {
+        throw new Error('Please enter a meaningful amount of max requests.');
+      }
       const response = await this.getMany(options);
 
-      return getAllResponses(response);
+      if (maxRequests === 1) {
+        return {
+          data: response.data as Array<M>,
+          responses: [response],
+          lastResponse: response,
+        };
+      }
+
+      return getAllResponses(response, maxRequests);
     }
 
     protected __addFromResponse(response: Response<M>): Response<M> {

--- a/packages/datx-jsonapi/src/decorateView.ts
+++ b/packages/datx-jsonapi/src/decorateView.ts
@@ -72,15 +72,8 @@ export function decorateView<U>(
       if (maxRequests < 1) {
         throw new Error('Please enter a meaningful amount of max requests.');
       }
-      const response = await this.getMany(options);
 
-      if (maxRequests === 1) {
-        return {
-          data: response.data as Array<M>,
-          responses: [response],
-          lastResponse: response,
-        };
-      }
+      const response = await this.getMany(options);
 
       return getAllResponses(response, maxRequests);
     }

--- a/packages/datx-jsonapi/src/decorateView.ts
+++ b/packages/datx-jsonapi/src/decorateView.ts
@@ -1,4 +1,11 @@
-import { IModelConstructor, IType, IViewConstructor, PureCollection, PureModel, View } from '@datx/core';
+import {
+  IModelConstructor,
+  IType,
+  IViewConstructor,
+  PureCollection,
+  PureModel,
+  View,
+} from '@datx/core';
 
 import { IJsonapiCollection } from './interfaces/IJsonapiCollection';
 import { IJsonapiModel } from './interfaces/IJsonapiModel';

--- a/packages/datx-jsonapi/src/helpers/utils.ts
+++ b/packages/datx-jsonapi/src/helpers/utils.ts
@@ -59,11 +59,11 @@ export async function getAllResponses<M extends IJsonapiModel = IJsonapiModel>(
   responses.push(response);
 
   while (response.next) {
+    requests++;
     if (requests > maxRequests) {
       break;
     }
     response = await response.next();
-    requests++;
     responses.push(response);
     data.push(...(response.data as Array<M>));
   }

--- a/packages/datx-jsonapi/src/helpers/utils.ts
+++ b/packages/datx-jsonapi/src/helpers/utils.ts
@@ -48,16 +48,22 @@ export function getModelClassRefs(
 
 export async function getAllResponses<M extends IJsonapiModel = IJsonapiModel>(
   response: Response<M>,
+  maxRequests = 50,
 ): Promise<IGetAllResponse<M>> {
   const data: Array<M> = [];
   const responses: Array<Response<M>> = [];
   let lastResponse = response;
+  let requests = 1;
 
   data.push(...(response.data as Array<M>));
   responses.push(response);
 
   while (response.next) {
+    if (requests > maxRequests) {
+      break;
+    }
     response = await response.next();
+    requests++;
     responses.push(response);
     data.push(...(response.data as Array<M>));
   }

--- a/packages/datx-jsonapi/src/helpers/utils.ts
+++ b/packages/datx-jsonapi/src/helpers/utils.ts
@@ -1,5 +1,8 @@
 import { IFieldDefinition, IReferenceDefinition, PureModel } from '@datx/core';
 import { getMeta } from '@datx/utils';
+import { IGetAllResponse } from '../interfaces/IGetAllResponse';
+import { IJsonapiModel } from '../interfaces/IJsonapiModel';
+import { Response } from '../Response';
 
 // eslint-disable-next-line no-var
 declare var window: object;
@@ -41,4 +44,29 @@ export function getModelClassRefs(
   });
 
   return refs;
+}
+
+export async function getAllResponses<M extends IJsonapiModel = IJsonapiModel>(
+  response: Response<M>,
+): Promise<IGetAllResponse<M>> {
+  const data: Array<M> = [];
+  const responses: Array<Response<M>> = [];
+  let lastResponse = response;
+
+  data.push(...(response.data as Array<M>));
+  responses.push(response);
+
+  while (response.next) {
+    response = await response.next();
+    responses.push(response);
+    data.push(...(response.data as Array<M>));
+  }
+
+  lastResponse = responses[responses.length - 1];
+
+  return {
+    data,
+    responses,
+    lastResponse,
+  };
 }

--- a/packages/datx-jsonapi/src/interfaces/IGetAllResponse.ts
+++ b/packages/datx-jsonapi/src/interfaces/IGetAllResponse.ts
@@ -1,0 +1,8 @@
+import { Response } from '../Response';
+import { IJsonapiModel } from './IJsonapiModel';
+
+export interface IGetAllResponse<T extends IJsonapiModel = IJsonapiModel> {
+  data: Array<T>;
+  responses: Array<Response<T>>;
+  lastMeta: object | undefined;
+}

--- a/packages/datx-jsonapi/src/interfaces/IGetAllResponse.ts
+++ b/packages/datx-jsonapi/src/interfaces/IGetAllResponse.ts
@@ -4,5 +4,5 @@ import { IJsonapiModel } from './IJsonapiModel';
 export interface IGetAllResponse<T extends IJsonapiModel = IJsonapiModel> {
   data: Array<T>;
   responses: Array<Response<T>>;
-  lastMeta: object | undefined;
+  lastResponse: Response<T>;
 }

--- a/packages/datx-jsonapi/src/interfaces/IJsonapiCollection.ts
+++ b/packages/datx-jsonapi/src/interfaces/IJsonapiCollection.ts
@@ -49,6 +49,7 @@ export interface IJsonapiCollection extends PureCollection {
   getAll<T extends IJsonapiModel = IJsonapiModel>(
     type: IType | IModelConstructor<T>,
     options?: IRequestOptions,
+    maxRequests?: number,
   ): Promise<IGetAllResponse<T>>;
 
   request<T extends IJsonapiModel = IJsonapiModel>(

--- a/packages/datx-jsonapi/src/interfaces/IJsonapiCollection.ts
+++ b/packages/datx-jsonapi/src/interfaces/IJsonapiCollection.ts
@@ -1,6 +1,7 @@
 import { IModelConstructor, IType, PureCollection, PureModel } from '@datx/core';
 
 import { Response } from '../Response';
+import { IGetAllResponse } from './IGetAllResponse';
 import { IJsonapiModel } from './IJsonapiModel';
 import { IRequestOptions } from './IRequestOptions';
 import { IResponse } from './JsonApi';
@@ -44,6 +45,11 @@ export interface IJsonapiCollection extends PureCollection {
     type: IType | IModelConstructor<T>,
     options?: IRequestOptions,
   ): Promise<Response<T>>;
+
+  getAll<T extends IJsonapiModel = IJsonapiModel>(
+    type: IType | IModelConstructor<T>,
+    options?: IRequestOptions,
+  ): IGetAllResponse<T>;
 
   request<T extends IJsonapiModel = IJsonapiModel>(
     url: string,

--- a/packages/datx-jsonapi/src/interfaces/IJsonapiCollection.ts
+++ b/packages/datx-jsonapi/src/interfaces/IJsonapiCollection.ts
@@ -49,7 +49,7 @@ export interface IJsonapiCollection extends PureCollection {
   getAll<T extends IJsonapiModel = IJsonapiModel>(
     type: IType | IModelConstructor<T>,
     options?: IRequestOptions,
-  ): IGetAllResponse<T>;
+  ): Promise<IGetAllResponse<T>>;
 
   request<T extends IJsonapiModel = IJsonapiModel>(
     url: string,

--- a/packages/datx-jsonapi/src/interfaces/IJsonapiView.ts
+++ b/packages/datx-jsonapi/src/interfaces/IJsonapiView.ts
@@ -11,5 +11,5 @@ export interface IJsonapiView<T extends IJsonapiModel = IJsonapiModel> extends V
 
   getOne(id: string, options?: IRequestOptions): Promise<Response<T>>;
   getMany(options?: IRequestOptions): Promise<Response<T>>;
-  getAll(options?: IRequestOptions): Promise<IGetAllResponse<T>>;
+  getAll(options?: IRequestOptions, maxRequests?: number): Promise<IGetAllResponse<T>>;
 }

--- a/packages/datx-jsonapi/src/interfaces/IJsonapiView.ts
+++ b/packages/datx-jsonapi/src/interfaces/IJsonapiView.ts
@@ -1,6 +1,7 @@
 import { View } from '@datx/core';
 
 import { Response } from '../Response';
+import { IGetAllResponse } from './IGetAllResponse';
 import { IJsonapiModel } from './IJsonapiModel';
 import { IRequestOptions } from './IRequestOptions';
 import { IResponse } from './JsonApi';
@@ -10,4 +11,5 @@ export interface IJsonapiView<T extends IJsonapiModel = IJsonapiModel> extends V
 
   getOne(id: string, options?: IRequestOptions): Promise<Response<T>>;
   getMany(options?: IRequestOptions): Promise<Response<T>>;
+  getAll(options?: IRequestOptions): Promise<IGetAllResponse<T>>;
 }

--- a/packages/datx-jsonapi/test/network/basics.test.ts
+++ b/packages/datx-jsonapi/test/network/basics.test.ts
@@ -15,6 +15,7 @@ import { clearAllCache } from '../../src/cache';
 
 import { setRequest, setupNetwork, confirmNetwork } from '../utils/api';
 import { Event, Image, TestStore } from '../utils/setup';
+import { Response } from '../../src/Response';
 
 const baseTransformRequest = config.transformRequest;
 const baseTransformResponse = config.transformResponse;
@@ -283,9 +284,10 @@ describe('Network basics', () => {
 
     expect(events.responses).toBeInstanceOf(Array);
     expect(events.responses.length).toBe(2);
-    expect(events.responses[events.responses.length - 1].next).toBeUndefined();
 
-    expect(events.lastMeta).toBeInstanceOf(Object);
+    expect(events.lastResponse).toBeInstanceOf(Response);
+    expect(events.lastResponse).toEqual(events.responses[events.responses.length - 1]);
+    expect(events.lastResponse.next).toBeUndefined();
   });
 
   it('should support record links', async () => {

--- a/packages/datx-jsonapi/test/network/basics.test.ts
+++ b/packages/datx-jsonapi/test/network/basics.test.ts
@@ -290,6 +290,22 @@ describe('Network basics', () => {
     expect(events.lastResponse.next).toBeUndefined();
   });
 
+  it('should throw an error if getAll maxRequests is less than 1', async () => {
+    const store = new TestStore();
+
+    try {
+      await store.getAll(Event, undefined, -1);
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+    }
+
+    try {
+      await store.getAll(Event, undefined, 0);
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+    }
+  });
+
   it('should support record links', async () => {
     setRequest({
       name: 'event-1',

--- a/packages/datx-jsonapi/test/network/basics.test.ts
+++ b/packages/datx-jsonapi/test/network/basics.test.ts
@@ -260,6 +260,34 @@ describe('Network basics', () => {
     }
   });
 
+  it('should fetch all pages', async () => {
+    setRequest({
+      name: 'events-1',
+      url: 'event',
+    });
+
+    setRequest({
+      name: 'events-2',
+      query: {
+        page: 2,
+      },
+      url: 'event',
+    });
+
+    const store = new TestStore();
+    const events = await store.getAll(Event);
+
+    expect(events.data).toBeInstanceOf(Array);
+    expect(events.data.length).toBe(6);
+    expect(events.data[events.data.length - 1].title).toBe('Test 6');
+
+    expect(events.responses).toBeInstanceOf(Array);
+    expect(events.responses.length).toBe(2);
+    expect(events.responses[events.responses.length - 1].next).toBeUndefined();
+
+    expect(events.lastMeta).toBeInstanceOf(Object);
+  });
+
   it('should support record links', async () => {
     setRequest({
       name: 'event-1',

--- a/packages/datx-jsonapi/test/views.test.ts
+++ b/packages/datx-jsonapi/test/views.test.ts
@@ -5,6 +5,7 @@ import { IJsonapiView, jsonapi, config } from '../src';
 import { setupNetwork, setRequest, confirmNetwork } from './utils/api';
 import { Event, TestStore } from './utils/setup';
 import { clearAllCache } from '../src/cache';
+import { Response } from '../src/Response';
 
 const baseTransformRequest = config.transformRequest;
 const baseTransformResponse = config.transformResponse;
@@ -164,6 +165,8 @@ describe('Views', () => {
 
       expect(store.eventsView.length).toBe(6);
       expect(store.eventsView.list[store.eventsView.length - 1]['title']).toBe('Test 6');
+
+      expect(events.lastResponse).toBeInstanceOf(Response);
     });
   });
 });

--- a/packages/datx-jsonapi/test/views.test.ts
+++ b/packages/datx-jsonapi/test/views.test.ts
@@ -168,5 +168,57 @@ describe('Views', () => {
 
       expect(events.lastResponse).toBeInstanceOf(Response);
     });
+
+    it('should support limiting the getAll requests', async () => {
+      setRequest({
+        name: 'events-1',
+        url: 'event',
+      });
+
+      class NewStore extends TestStore {
+        public static views = {
+          eventsView: {
+            mixins: [jsonapi],
+            modelType: Event,
+          },
+        };
+
+        public eventsView!: IJsonapiView;
+      }
+
+      const store = new NewStore();
+      const events = await store.eventsView.getAll(undefined, 1);
+
+      expect(events.data.length).toBe(4);
+      expect(events.data[events.data.length - 1]['title']).toBe('Test 4');
+      expect(events.responses.length).toBe(1);
+    });
+
+    it('should throw an error if maxRequests is less than 1', async () => {
+      class NewStore extends TestStore {
+        public static views = {
+          eventsView: {
+            mixins: [jsonapi],
+            modelType: Event,
+          },
+        };
+
+        public eventsView!: IJsonapiView;
+      }
+
+      const store = new NewStore();
+
+      try {
+        await store.eventsView.getAll(undefined, -1);
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+      }
+
+      try {
+        await store.eventsView.getAll(undefined, 0);
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+      }
+    });
   });
 });

--- a/packages/datx-jsonapi/test/views.test.ts
+++ b/packages/datx-jsonapi/test/views.test.ts
@@ -131,5 +131,39 @@ describe('Views', () => {
         expect(store.test.length).toBe(6);
       }
     });
+
+    it('should support getting all records', async () => {
+      setRequest({
+        name: 'events-1',
+        url: 'event',
+      });
+      setRequest({
+        name: 'events-2',
+        query: {
+          page: '2',
+        },
+        url: 'event',
+      });
+
+      class NewStore extends TestStore {
+        public static views = {
+          eventsView: {
+            mixins: [jsonapi],
+            modelType: Event,
+          },
+        };
+
+        public eventsView!: IJsonapiView;
+      }
+
+      const store = new NewStore();
+      const events = await store.eventsView.getAll();
+
+      expect(events.data.length).toBe(6);
+      expect(events.data[events.data.length - 1]['title']).toBe('Test 6');
+
+      expect(store.eventsView.length).toBe(6);
+      expect(store.eventsView.list[store.eventsView.length - 1]['title']).toBe('Test 6');
+    });
   });
 });


### PR DESCRIPTION
Add `getAll` method for collection and view that will fetch all pages for the given type from the server.

Return the most common stuff needed for further data usage:

```typescript
interface IGetAllResponse<T extends IJsonapiModel = IJsonapiModel> {
 data: Array<T>;
 responses: Array<Response<T>>;
 lastResponse: Response<T>;
}
```