### PR TITLE
Export url helpers

### DIFF
--- a/packages/datx-jsonapi/src/index.ts
+++ b/packages/datx-jsonapi/src/index.ts
@@ -17,6 +17,11 @@ export {
   saveModel,
 } from './helpers/model';
 
+export {
+  prepareQuery,
+  buildUrl
+} from './helpers/url';
+
 export { BaseJsonapiRequest } from './BaseRequest';
 
 export { ICollectionFetchOpts } from './interfaces/ICollectionFetchOpts';


### PR DESCRIPTION
I exported these helpers for integration with React SWR hooks like this:
```
export class Client extends jsonapi(Collection) {
	/**
	 *
	 * @param {string} type Record type
	 * @param {number|string} type Record id
	 * @param {IRequestOptions} [options] Server options
	 */
	public queryResource<TModel extends Resource = Resource>(
		type: IType | IModelConstructor<TModel>,
		id: string,
		options?: IRequestOptions
	) {
		const modelType = getModelType(type);
		const query = prepareQuery(modelType, id, undefined, options);

		const fetcher = () => this.getOne<TModel>(type, id, options);

		return {
			key: query.url,
			fetcher,
		};
	}
	...
}
```

so I can do something like this inside hook:
```
query = client.queryResources(type, options);
const swr = useSWR<Response<TModel>, Response<TModel>>(query.key, query.fetcher, config);
```

I'm also experimenting with `buildUrl` and `useRelatedResources([Post, 1, 'comments'])` where you can fetch paginated relationship via URL like this `/posts/1/comments`...