### PR TITLE
Fix absolute URL detection

### DIFF
--- a/packages/datx-jsonapi/src/consts.ts
+++ b/packages/datx-jsonapi/src/consts.ts
@@ -7,4 +7,4 @@ export const MODEL_PROP_FIELD = 'jsonapiProp';
 export const MODEL_QUEUE_FIELD = 'jsonapiQueue';
 export const MODEL_RELATED_FIELD = 'jsonapiRelated';
 
-export const URL_REGEX = /^(?:http(s)?:\/\/)[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/;
+export const URL_REGEX = /^((https?\:)?\/\/)/;

--- a/packages/datx-jsonapi/test/issues.ts
+++ b/packages/datx-jsonapi/test/issues.ts
@@ -2,7 +2,7 @@
 import { Collection, Model, prop } from 'datx';
 import * as fetch from 'isomorphic-fetch';
 import { computed } from 'mobx';
-import { config, getModelMeta, getModelRefMeta, jsonapi } from '../src';
+import { buildUrl, config, getModelMeta, getModelRefMeta, jsonapi } from '../src';
 import { clearAllCache } from '../src/cache';
 
 import mockApi from './utils/api';
@@ -218,5 +218,13 @@ describe('Issues', () => {
 
     const lineItem2 = new LineItem({ }, store);
     await lineItem2.save();
+  });
+
+  it('should not prefix url with base url if it\'s already absolute and contains a port', async () => {
+    const url = 'http://localhost:3000/books';
+
+    const query = buildUrl(url)
+
+    expect(query.url).toBe(url);
   });
 });


### PR DESCRIPTION
This fix `buildUrl` and also `store.request` absolute URL detection if URL contains PORT segment. 
This is v1 fix for this issue #182