### PR TITLE
fix(docs): json api chapter datx version missmatch

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -389,6 +389,9 @@
       "version-2.0.0/mixins/version-2.0.0-building-your-own-mixin": {
         "title": "Build your own mixin"
       },
+      "version-2.0.0/mixins/version-2.0.0-jsonapi-mixin": {
+        "title": "JSONAPI Mixin"
+      },
       "version-2.0.0/mixins/version-2.0.0-network-mixin": {
         "title": "Network Mixin"
       },

--- a/website/versioned_docs/version-2.0.0/mixins/jsonapi-mixin.md
+++ b/website/versioned_docs/version-2.0.0/mixins/jsonapi-mixin.md
@@ -1,0 +1,20 @@
+---
+id: version-2.0.0-jsonapi-mixin
+title: JSONAPI Mixin
+original_id: jsonapi-mixin
+---
+See [JSON API chapter](../jsonapi/jsonapi-getting-started).  
+
+## Documentation
+
+- [Basic configuration](../jsonapi/jsonapi-basic-configuration)
+- [Network configuration](../jsonapi/jsonapi-network-configuration)
+- [Network usage](../jsonapi/jsonapi-network-usage)
+- [Spec compliance](../jsonapi/jsonapi-spec-compliance)
+- [Model](../jsonapi/jsonapi-model)
+- [Collection](../jsonapi/jsonapi-collection)
+- [View](../jsonapi/jsonapi-view)
+- [Response](../jsonapi/jsonapi-response)
+- [Config](../jsonapi/jsonapi-config)
+- [Utils](../jsonapi/json-api-utils)
+- [TypeScript Interfaces](../jsonapi/jsonapi-typescript-interfaces)


### PR DESCRIPTION
Without figuring out exactly how docusaurus works it seems that it falls back to an older version of a page if a given page is not found in the current version. This causes https://datx.dev/docs/mixins/jsonapi-mixin to show page version-1.0.0-jsonapi-mixin even though in v2 there is a separate section for JSONAPI. These two pages additionally give conflicting instructions on which dependencies to install. This PR adds page version-2.0.0-jsonapi-mixin which points the user to a given section. 