### PR TITLE
fix(docs): update references to packages in v2, add separate pages for each available mixin that were missing

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -389,6 +389,9 @@
       "version-2.0.0/mixins/version-2.0.0-building-your-own-mixin": {
         "title": "Build your own mixin"
       },
+      "version-2.0.0/mixins/version-2.0.0-jsonapi-angular-mixin": {
+        "title": "JSONAPI Angular Mixin"
+      },
       "version-2.0.0/mixins/version-2.0.0-network-mixin": {
         "title": "Network Mixin"
       },

--- a/website/versioned_docs/version-2.0.0/jsonapi-angular/base-fetch.md
+++ b/website/versioned_docs/version-2.0.0/jsonapi-angular/base-fetch.md
@@ -6,7 +6,7 @@ original_id: base-fetch
 
 By default, the library will use the FetchAPI to do all the networking. This is not ideal when using Angular as it would remove some useful features like interceptors and request cancellation.
 
-`datx-jsonapi-angular` implements some hooks which can be used in combination with a custom `baseFetch` implementation to get those features back.
+`@datx/jsonapi-angular` implements some hooks which can be used in combination with a custom `baseFetch` implementation to get those features back.
 
 Here is an example of the implementation, but you might have some other needs:
 

--- a/website/versioned_docs/version-2.0.0/mixins/jsonapi-angular-mixin.md
+++ b/website/versioned_docs/version-2.0.0/mixins/jsonapi-angular-mixin.md
@@ -1,0 +1,10 @@
+---
+id: version-2.0.0-jsonapi-angular-mixin
+title: JSONAPI Angular Mixin
+original_id: jsonapi-angular-mixin
+---
+See [JSON API Angular chapter](../jsonapi-angular/mixin). Functionality is similar to JSON API which has separate [JSON API chapter](../jsonapi/jsonapi-getting-started).
+
+## Documentation
+
+- [Base fetch](../jsonapi-angular/mixin)

--- a/website/versioned_docs/version-2.0.0/mixins/network-mixin.md
+++ b/website/versioned_docs/version-2.0.0/mixins/network-mixin.md
@@ -4,13 +4,13 @@ title: Network Mixin
 original_id: network-mixin
 ---
 
-If you're using an API for your application, you can install `datx-network` to take the full advantage of the `datx` library:
+If you're using an API for your application, you can install `@datx/network` to take the full advantage of the `@datx/core` library:
 
 ```bash
-npm install --save datx datx-network mobx
+npm install --save @datx/core @datx/network mobx
 ```
 
-**Note** If you're using the [JSON API specification](https://jsonapi.org/), check out [datx-jsonapi](./jsonapi-mixin) instead.
+**Note** If you're using the [JSON API specification](https://jsonapi.org/), check out [@datx/jsonapi](./jsonapi-mixin) instead. Additionally, there is [@datx/jsonapi-angular] which works with RxJS [Observables](https://rxjs.dev/guide/observable).
 
 ## Polyfilling
 

--- a/website/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-2.0.0-sidebars.json
@@ -15,6 +15,7 @@
       "version-2.0.0-mixins/with-patches",
       "version-2.0.0-mixins/network-mixin",
       "version-2.0.0-mixins/jsonapi-mixin",
+      "version-2.0.0-mixins/jsonapi-angular-mixin",
       "version-2.0.0-mixins/building-your-own-mixin"
     ],
     "API Reference": [


### PR DESCRIPTION
JSONAPI Angular mixin page is added/fixed in #399.