### PR TITLE
fix(docs): jsonapi-angular base fetch example correct references and casts

### DIFF
--- a/website/versioned_docs/version-2.0.0/jsonapi-angular/base-fetch.md
+++ b/website/versioned_docs/version-2.0.0/jsonapi-angular/base-fetch.md
@@ -16,7 +16,7 @@ Here is an example of the implementation, but you might have some other needs:
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { config, IResponseObject } from '@datx/jsonapi';
-import { IResponseHeaders } from 'datx-jsonapi/dist/interfaces/IResponseHeaders';
+import { IResponseHeaders } from '@datx/jsonapi/dist/interfaces/IResponseHeaders';
 import { Observable } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
 
@@ -50,7 +50,7 @@ export class CustomFetchService {
           headers: response.headers as unknown as IResponseHeaders, // The interface actually matches
           requestHeaders,
           status: response.status,
-        };
+        } as IResponseObject;
       }),
     );
 


### PR DESCRIPTION
Just another minor thing I noticed while writing the page on DatX angular-related stuff.