### PR TITLE
Add Angular example repo docs chapter

### DIFF
--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -333,10 +333,13 @@
         "title": "Using the collection"
       },
       "version-2.0.0/jsonapi-angular/version-2.0.0-base-fetch": {
-        "title": "Angular JSON:API baseFetch"
+        "title": "baseFetch"
+      },
+      "version-2.0.0/jsonapi-angular/version-2.0.0-example-repo": {
+        "title": "Example repo"
       },
       "version-2.0.0/jsonapi-angular/version-2.0.0-mixin": {
-        "title": "Angular JSON:API mixin"
+        "title": "Mixin"
       },
       "version-2.0.0/jsonapi/version-2.0.0-jsonapi-basic-configuration": {
         "title": "Basic configuration"
@@ -389,11 +392,11 @@
       "version-2.0.0/mixins/version-2.0.0-building-your-own-mixin": {
         "title": "Build your own mixin"
       },
-      "version-2.0.0/mixins/version-2.0.0-jsonapi-mixin": {
-        "title": "JSONAPI Mixin"
-      },
       "version-2.0.0/mixins/version-2.0.0-jsonapi-angular-mixin": {
         "title": "JSONAPI Angular Mixin"
+      },
+      "version-2.0.0/mixins/version-2.0.0-jsonapi-mixin": {
+        "title": "JSONAPI Mixin"
       },
       "version-2.0.0/mixins/version-2.0.0-network-mixin": {
         "title": "Network Mixin"

--- a/website/versioned_docs/version-2.0.0/jsonapi-angular/base-fetch.md
+++ b/website/versioned_docs/version-2.0.0/jsonapi-angular/base-fetch.md
@@ -1,6 +1,6 @@
 ---
 id: version-2.0.0-base-fetch
-title: Angular JSON:API baseFetch
+title: baseFetch
 original_id: base-fetch
 ---
 

--- a/website/versioned_docs/version-2.0.0/jsonapi-angular/example-repo.md
+++ b/website/versioned_docs/version-2.0.0/jsonapi-angular/example-repo.md
@@ -1,0 +1,7 @@
+---
+id: version-2.0.0-example-repo
+title: Example repo
+original_id: example-repo
+---
+
+An example repository on how to integrate DatX into Angular can be found [here](https://github.com/infinum/js-angular-datx-example).

--- a/website/versioned_docs/version-2.0.0/jsonapi-angular/mixin.md
+++ b/website/versioned_docs/version-2.0.0/jsonapi-angular/mixin.md
@@ -1,6 +1,6 @@
 ---
 id: version-2.0.0-mixin
-title: Angular JSON:API mixin
+title: Mixin
 original_id: mixin
 ---
 

--- a/website/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-2.0.0-sidebars.json
@@ -55,7 +55,8 @@
     ],
     "JSON API Angular": [
       "version-2.0.0-jsonapi-angular/mixin",
-      "version-2.0.0-jsonapi-angular/base-fetch"
+      "version-2.0.0-jsonapi-angular/base-fetch",
+      "version-2.0.0-jsonapi-angular/example-repo"
     ],
     "Migration guide": [
       "version-2.0.0-migration-guide/breaking-changes",


### PR DESCRIPTION
This PR adds the Angular example repo page to the docs.

![image](https://user-images.githubusercontent.com/373850/136380234-896ea7cd-8a5f-4388-8d7b-8575c2dc5afb.png)
