### PR TITLE
Implement stable sort for URL search params

### DIFF
--- a/packages/datx-jsonapi/src/NetworkUtils.ts
+++ b/packages/datx-jsonapi/src/NetworkUtils.ts
@@ -52,6 +52,13 @@ export interface IConfigType {
   transformRequest(options: ICollectionFetchOpts): ICollectionFetchOpts;
   transformResponse(response: IRawResponse): IRawResponse;
   usePatchWhenPossible: boolean;
+
+  /**
+   * Enable stable sort of url search params using `URLSearchParams.sort()` method.
+   * It will also sort include params using `Array.sort()` method.
+   * @default false
+   */
+  sortParams?: boolean;
 }
 
 export const config: IConfigType = {
@@ -70,6 +77,7 @@ export const config: IConfigType = {
   },
 
   encodeQueryString: false,
+  sortParams: false,
 
   // Reference of the fetch method that should be used
   fetchReference:

--- a/packages/datx-jsonapi/src/helpers/url.ts
+++ b/packages/datx-jsonapi/src/helpers/url.ts
@@ -49,7 +49,9 @@ function prepareSort(sort?: string | Array<string>): Array<string> {
 }
 
 function prepareIncludes(include?: string | Array<string>): Array<string> {
-  return include ? [`include=${include}`] : [];
+  return include
+    ? [`include=${config.sortParams && Array.isArray(include) ? include.sort() : include}`]
+    : [];
 }
 
 function prepareFields(fields: Record<string, string | Array<string>>): Array<string> {
@@ -121,7 +123,19 @@ export function buildUrl(
     params = params.map(encodeParam);
   }
 
-  const baseUrl: string = appendParams(prefixUrl(url, containsBase), params);
+  let baseUrl: string = appendParams(prefixUrl(url, containsBase), params);
+
+  if (config.sortParams) {
+    const [url, searchParams] = baseUrl.split('?');
+
+    if (searchParams) {
+      const urlSearchParams = new URLSearchParams(searchParams);
+
+      urlSearchParams.sort();
+
+      baseUrl = `${url}?${urlSearchParams.toString()}`;
+    }
+  }
 
   return { data, headers, url: baseUrl };
 }

--- a/packages/datx-jsonapi/test/network/params.test.ts
+++ b/packages/datx-jsonapi/test/network/params.test.ts
@@ -2,7 +2,7 @@ import * as fetch from 'isomorphic-fetch';
 
 import { setupNetwork, setRequest, confirmNetwork } from '../utils/api';
 import { TestStore, Event } from '../utils/setup';
-import { ParamArrayType } from '../../src';
+import { buildUrl, IRequestOptions, ParamArrayType } from '../../src';
 import { clearAllCache } from '../../src/cache';
 import { config } from '../../src/NetworkUtils';
 
@@ -289,6 +289,58 @@ describe('params', () => {
       const store = new TestStore();
 
       await store.request('event', 'GET', undefined, { queryParams: { filter: { name: 'ć=' } } });
+    });
+  });
+
+  describe('URL search params stable sort', () => {
+    const options1: IRequestOptions = {
+      queryParams: {
+        filter: {
+          first: '1',
+          second: '2',
+        },
+        sort: 'name',
+        include: ['first', 'second'],
+        fields: {
+          first: '1',
+          second: '2',
+        },
+        custom: ['a=1', 'b=2', { key: 'c', value: '3' }],
+      },
+    };
+
+    const options2: IRequestOptions = {
+      queryParams: {
+        filter: {
+          second: '2',
+          first: '1',
+        },
+        sort: 'name',
+        include: ['second', 'first'],
+        fields: {
+          second: '2',
+          first: '1',
+        },
+        custom: [{ key: 'c', value: '3' }, 'b=2', 'a=1'],
+      },
+    };
+
+    it('should not sort URL search params if `sortParams` config is set to false or undefined', () => {
+      config.sortParams = false;
+
+      const urlObj1 = buildUrl('event', undefined, options1);
+      const urlObj2 = buildUrl('event', undefined, options2);
+
+      expect(urlObj1.url).not.toEqual(urlObj2.url);
+    });
+
+    it('should sort URL search params if `sortParams` config is set to true', async () => {
+      config.sortParams = true;
+
+      const urlObj1 = buildUrl('event', undefined, options1);
+      const urlObj2 = buildUrl('event', undefined, options2);
+
+      expect(urlObj1.url).toEqual(urlObj2.url);
     });
   });
 });


### PR DESCRIPTION
Please select all that apply:

* [ ] This PR contains a new feature
* [x] This PR updates an existing feature
* [ ] This PR contains bugfixes
* [x] This PR contains all the relevant tests
* [ ] This PR creates a breaking change

This PR adds additional config flag `config.sortParams`.
It will enable stable sort of URL search params using `URLSearchParams.sort()` method and sort of `include` params using `Array.sort()` method.
