### PR TITLE
fix: Ignore undefined properties on upsert

### DIFF
--- a/packages/datx-jsonapi/test/issues.test.ts
+++ b/packages/datx-jsonapi/test/issues.test.ts
@@ -315,4 +315,27 @@ describe('Issues', () => {
     snapshot = foo.toJSON();
     expect(snapshot.value).toBe('TEST:321');
   });
+
+  it('should work with partial responses', async () => {
+    setRequest({
+      name: 'event-1b',
+      url: 'event/1',
+    });
+
+    setRequest({
+      method: 'PATCH',
+      name: 'event-1g',
+      url: 'event/1',
+    });
+
+    const store = new TestStore();
+    const eventResponse = await store.fetch(Event, '1');
+    const event = eventResponse.data as Event;
+
+    expect(event.title).toBe('Test 1');
+
+    await event.save();
+
+    expect(event.title).toBe('Test 1');
+  });
 });

--- a/packages/datx-jsonapi/test/mock/event-1g.json
+++ b/packages/datx-jsonapi/test/mock/event-1g.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "1",
+    "type": "event",
+    "attributes": {
+      "date": "2017-03-19"
+    },
+    "links": {
+      "self": "https://example.com/event/1234"
+    }
+  }
+}

--- a/packages/datx/src/helpers/collection.ts
+++ b/packages/datx/src/helpers/collection.ts
@@ -47,7 +47,7 @@ export function upsertModel(
     keys.forEach((key: string) => {
       const isBackRefKey = Boolean(fields?.[key]?.referenceDef?.property);
       const result = modelMapParse(TypeModel, data, key);
-      if (!(isBackRefKey && result === undefined && !(key in data))) {
+      if (result !== undefined && !isBackRefKey) {
         parsedData[key] = result;
       }
     });


### PR DESCRIPTION
Please select all that apply:

* [ ] This PR contains a new feature
* [ ] This PR updates an existing feature
* [x] This PR contains bugfixes
* [x] This PR contains all the relevant tests
* [ ] This PR creates a breaking change

Please describe the differences between the current and new behavior

With this changes, the properties that are not received from tne API (and are therefore undefined) will not be removed from the existing model when upserting.