### PR TITLE
chore: bump versions for datx jsonapi-angular release

### DIFF
--- a/packages/datx-jsonapi-angular/package.json
+++ b/packages/datx-jsonapi-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datx/jsonapi-angular",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "scripts": {
     "ng": "ng",
     "build": "ng build datx-jsonapi-angular && npm run copy-license && npm run copy-readme",

--- a/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/package.json
+++ b/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datx/jsonapi-angular",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "DatX mixin for Angular JSON API support",
   "sideEffects": false,
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,11 +1871,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datx/core@2.4.6, @datx/core@workspace:packages/datx":
+"@datx/core@2.4.8, @datx/core@workspace:packages/datx":
   version: 0.0.0-use.local
   resolution: "@datx/core@workspace:packages/datx"
   dependencies:
-    "@datx/utils": 2.4.5
+    "@datx/utils": 2.4.8
     "@rollup/plugin-commonjs": ^22.0.0
     "@rollup/plugin-node-resolve": ^13.3.0
     "@rollup/plugin-typescript": ^8.3.2
@@ -1907,10 +1907,10 @@ __metadata:
     "@angular/platform-browser": ~14.2.0
     "@angular/platform-browser-dynamic": ~14.1.2
     "@angular/router": ~14.2.0
-    "@datx/core": 2.4.6
-    "@datx/jsonapi": 2.4.6
-    "@datx/network": 2.4.6
-    "@datx/utils": 2.4.5
+    "@datx/core": 2.4.8
+    "@datx/jsonapi": 2.4.8
+    "@datx/network": 2.4.8
+    "@datx/utils": 2.4.8
     "@types/jest": ^28.1.1
     "@types/node": ^18.7.6
     jest: ^28.1.1
@@ -1927,13 +1927,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datx/jsonapi@2.4.6, @datx/jsonapi@workspace:packages/datx-jsonapi":
+"@datx/jsonapi@2.4.8, @datx/jsonapi@workspace:packages/datx-jsonapi":
   version: 0.0.0-use.local
   resolution: "@datx/jsonapi@workspace:packages/datx-jsonapi"
   dependencies:
-    "@datx/core": 2.4.6
-    "@datx/network": 2.4.6
-    "@datx/utils": 2.4.5
+    "@datx/core": 2.4.8
+    "@datx/network": 2.4.8
+    "@datx/utils": 2.4.8
     "@rollup/plugin-commonjs": ^22.0.0
     "@rollup/plugin-node-resolve": ^13.3.0
     "@rollup/plugin-typescript": ^8.3.2
@@ -1955,12 +1955,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datx/network@2.4.6, @datx/network@workspace:packages/datx-network":
+"@datx/network@2.4.8, @datx/network@workspace:packages/datx-network":
   version: 0.0.0-use.local
   resolution: "@datx/network@workspace:packages/datx-network"
   dependencies:
-    "@datx/core": 2.4.6
-    "@datx/utils": 2.4.5
+    "@datx/core": 2.4.8
+    "@datx/utils": 2.4.8
     "@rollup/plugin-commonjs": ^22.0.0
     "@rollup/plugin-node-resolve": ^13.3.0
     "@rollup/plugin-typescript": ^8.3.2
@@ -1979,7 +1979,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@datx/utils@2.4.5, @datx/utils@workspace:packages/datx-utils":
+"@datx/utils@2.4.8, @datx/utils@workspace:packages/datx-utils":
   version: 0.0.0-use.local
   resolution: "@datx/utils@workspace:packages/datx-utils"
   dependencies:


### PR DESCRIPTION
Please select all that apply:

* [ ] This PR contains a new feature
* [x] This PR updates an existing feature
* [ ] This PR contains bugfixes
* [ ] This PR contains all the relevant tests
* [ ] This PR creates a breaking change

Update package-lock and bump angular package to 2.4.9 in order to be able to publish
