### PR TITLE
Fix angular-jsonapi-imports

### DIFF
--- a/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/Response.ts
+++ b/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/Response.ts
@@ -1,5 +1,4 @@
-import { fetchLink, Response as PromiseResponse } from '@datx/jsonapi';
-import { IResponseSnapshot } from '@datx/jsonapi/dist/interfaces/IResponseSnapshot';
+import { fetchLink, IResponseSnapshot, Response as PromiseResponse } from '@datx/jsonapi';
 import { Observable } from 'rxjs';
 import { observableWrapper } from './helpers/wrapper';
 import { IJsonapiModel } from './interfaces/IJsonapiModel';

--- a/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/datx.module.ts
+++ b/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/datx.module.ts
@@ -1,5 +1,5 @@
 import { APP_INITIALIZER, ModuleWithProviders, NgModule, Optional } from '@angular/core';
-import { IConfigType } from '@datx/jsonapi/dist/NetworkUtils';
+import { IConfigType } from '@datx/jsonapi';
 import { CachingStrategy } from '@datx/network';
 import { initDatxFactory } from './helpers/init-datx-factory';
 import { DATX_CONFIG } from './injection-tokens';

--- a/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/helpers/init-datx-factory.ts
+++ b/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/helpers/init-datx-factory.ts
@@ -1,5 +1,4 @@
-import { config } from '@datx/jsonapi';
-import { IConfigType } from '@datx/jsonapi/dist/NetworkUtils';
+import { config, IConfigType } from '@datx/jsonapi';
 import { DEFAULT_DATX_ANGULAR_JSON_API_CONFIG } from '../datx.module';
 import { CustomFetchService } from '../services/custom-fetch/custom-fetch.service';
 

--- a/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/injection-tokens.ts
+++ b/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/injection-tokens.ts
@@ -1,5 +1,5 @@
 import { InjectionToken } from '@angular/core';
-import { IConfigType } from '@datx/jsonapi/dist/NetworkUtils';
+import { IConfigType } from '@datx/jsonapi';
 
 export const DATX_CONFIG = new InjectionToken<Partial<IConfigType>>('DATX_CONFIG');
 

--- a/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/services/collection/collection.service.ts
+++ b/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/services/collection/collection.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable } from '@angular/core';
 import { IModelConstructor, IRawModel, IType } from '@datx/core';
-import { IRequestOptions } from '@datx/jsonapi';
-import { IRecord } from '@datx/jsonapi/dist/interfaces/JsonApi';
+import { IRecord, IRequestOptions } from '@datx/jsonapi';
 import { EMPTY, Observable } from 'rxjs';
 import { expand, map, mapTo, reduce } from 'rxjs/operators';
 import { APP_COLLECTION } from '../../injection-tokens';
@@ -12,7 +11,7 @@ import { Response } from '../../Response';
 @Injectable()
 export abstract class CollectionService<
   TModel extends IJsonapiModel,
-  TCollection extends IJsonapiCollection
+  TCollection extends IJsonapiCollection,
 > {
   protected abstract readonly ctor: IModelConstructor<TModel>;
   private readonly maxPageSize = 1000;

--- a/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/services/collection/collection.testing.service.ts
+++ b/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/services/collection/collection.testing.service.ts
@@ -1,8 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { IModelConstructor, IRawModel, IType } from '@datx/core';
-import { IRequestOptions } from '@datx/jsonapi';
-import { IRecord } from '@datx/jsonapi/dist/interfaces/JsonApi';
+import { IRecord, IRequestOptions } from '@datx/jsonapi';
 import { Observable, of, throwError } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { APP_COLLECTION } from '../../injection-tokens';
@@ -20,8 +19,9 @@ function asyncData<TData>(data: TData): Observable<TData> {
 @Injectable()
 export abstract class CollectionTestingService<
   TModel extends IJsonapiModel,
-  TCollection extends IJsonapiCollection
-> implements ExtractPublic<CollectionService<TModel, TCollection>> {
+  TCollection extends IJsonapiCollection,
+> implements ExtractPublic<CollectionService<TModel, TCollection>>
+{
   protected abstract ctor: IModelConstructor<TModel>;
 
   constructor(@Inject(APP_COLLECTION) protected readonly collection: TCollection) {}

--- a/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/services/custom-fetch/custom-fetch.service.ts
+++ b/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/src/lib/services/custom-fetch/custom-fetch.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { config, IRawResponse } from '@datx/jsonapi';
-import { IResponseHeaders } from '@datx/utils/dist/interfaces/IResponseHeaders';
+import { IResponseHeaders } from '@datx/utils';
 import { Observable } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
 
@@ -34,7 +34,7 @@ export class CustomFetchService {
         map((response) => {
           return {
             data: response.body,
-            headers: (response.headers as unknown) as IResponseHeaders, // The interface actually matches
+            headers: response.headers as unknown as IResponseHeaders, // The interface actually matches
             requestHeaders,
             status: response.status,
           } as IRawResponse;

--- a/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/test/network/basic.test.ts
+++ b/packages/datx-jsonapi-angular/projects/datx-jsonapi-angular/test/network/basic.test.ts
@@ -4,9 +4,9 @@ import {
   getModelLinks,
   getModelMeta,
   getModelRefMeta,
+  IDefinition,
   modelToJsonApi,
 } from '@datx/jsonapi';
-import { IDefinition } from '@datx/jsonapi/dist/interfaces/JsonApi';
 import { Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { IJsonapiModel, Response } from '../../src/public-api';

--- a/packages/datx-jsonapi/src/index.ts
+++ b/packages/datx-jsonapi/src/index.ts
@@ -30,9 +30,10 @@ export { IJsonapiModel } from './interfaces/IJsonapiModel';
 export { IJsonapiView } from './interfaces/IJsonapiView';
 export { IRawResponse } from './interfaces/IRawResponse';
 export { IRequestOptions } from './interfaces/IRequestOptions';
-export { IResponse } from './interfaces/JsonApi';
+export { IResponseSnapshot } from './interfaces/IResponseSnapshot';
+export { IResponse, IRecord, IDefinition } from './interfaces/JsonApi';
 
-export { config, fetchLink } from './NetworkUtils';
+export { config, fetchLink, IConfigType } from './NetworkUtils';
 
 export {
   BaseRequest,


### PR DESCRIPTION
Please select all that apply:

* [ ] This PR contains a new feature
* [ ] This PR updates an existing feature
* [x] This PR contains bugfixes
* [ ] This PR contains all the relevant tests
* [ ] This PR creates a breaking change

This PR fixes imports in the `jsonapi-angular` package. Some of the interfaces had import paths to `dist` folder, I have added the missing interfaces to the `index.ts` of `datx-jsonapi` and updated imports in `jsonapi-angular` package. 