### PR TITLE
Return list when headers.forEach is undefined

### DIFF
--- a/packages/datx-jsonapi/src/Response.ts
+++ b/packages/datx-jsonapi/src/Response.ts
@@ -374,13 +374,13 @@ export class Response<T extends IJsonapiModel, P = IAsync<T>> {
         options.networkConfig = options.networkConfig || {};
         options.networkConfig.headers = this.requestHeaders;
         this.__cache[name] = (): P =>
-          fetchLink<T>(
+          (fetchLink<T>(
             link,
             this.collection,
             options,
             this.views,
             ResponseConstructor,
-          ) as unknown as P;
+          ) as unknown) as P;
       }
     }
 

--- a/packages/datx-jsonapi/src/Response.ts
+++ b/packages/datx-jsonapi/src/Response.ts
@@ -29,7 +29,7 @@ function serializeHeaders(
   if (headers instanceof Array) {
     return headers;
   }
-  
+
   const list: Array<[string, string]> = [];
 
   if (!headers.forEach) {
@@ -374,13 +374,13 @@ export class Response<T extends IJsonapiModel, P = IAsync<T>> {
         options.networkConfig = options.networkConfig || {};
         options.networkConfig.headers = this.requestHeaders;
         this.__cache[name] = (): P =>
-          (fetchLink<T>(
+          fetchLink<T>(
             link,
             this.collection,
             options,
             this.views,
             ResponseConstructor,
-          ) as unknown) as P;
+          ) as unknown as P;
       }
     }
 

--- a/packages/datx-jsonapi/src/Response.ts
+++ b/packages/datx-jsonapi/src/Response.ts
@@ -29,9 +29,12 @@ function serializeHeaders(
   if (headers instanceof Array) {
     return headers;
   }
-
+  
   const list: Array<[string, string]> = [];
 
+  if (!headers.forEach) {
+    return list;
+  }
   headers.forEach((value: string, key: string) => {
     list.push([key, value]);
   });


### PR DESCRIPTION
Please select all that apply:

* [ ] This PR contains a new feature
* [ ] This PR updates an existing feature
* [x] This PR contains bugfixes
* [ ] This PR contains all the relevant tests
* [ ] This PR creates a breaking change

When using MSW, the Headers object is a plain javascript object and does not satisfy the IResponseHeaders interface (does not contain forEach) which crashes header serialization.
