### PR TITLE
Refactor the default fetchReference

### DIFF
--- a/packages/datx-jsonapi/src/NetworkUtils.ts
+++ b/packages/datx-jsonapi/src/NetworkUtils.ts
@@ -61,6 +61,14 @@ export interface IConfigType {
   sortParams?: boolean;
 }
 
+/**
+ * Tries to get the built-in fetch reference. If it's a browser, use window to avoid any potential need for polyfills, but use globalThis in Node.js
+ */
+const fetchReference =
+  (isBrowser
+    ? typeof window.fetch === 'function' && window.fetch.bind(window)
+    : typeof globalThis.fetch === 'function' && globalThis.fetch.bind(globalThis)) || undefined;
+
 export const config: IConfigType = {
   // Base URL for all API calls
   baseUrl: '/',
@@ -80,12 +88,7 @@ export const config: IConfigType = {
   sortParams: false,
 
   // Reference of the fetch method that should be used
-  fetchReference:
-    (isBrowser &&
-      'fetch' in window &&
-      typeof window.fetch === 'function' &&
-      window.fetch.bind(window)) ||
-    undefined,
+  fetchReference,
 
   // Determines how will the request param arrays be stringified
   paramArrayType: ParamArrayType.CommaSeparated, // As recommended by the spec


### PR DESCRIPTION
Please select all that apply:

* [ ] This PR contains a new feature
* [x] This PR updates an existing feature
* [x] This PR contains bugfixes
* [x] This PR contains all the relevant tests
* [ ] This PR creates a breaking change

Please describe the differences between the current and new behavior:
This PR refactors the default behavior for fetchReferences to make them work in node.js (since we have fetch there too now). It still checks for the browser and uses `window` there to avoid any need for additional `globalThis` polyfills.

Addresses the #1154 issue
