### PR TITLE
fix: transform deprecated prop import to Attribute

### DIFF
--- a/packages/datx-codemod/src/transforms/__testfixtures__/prop-to-attribute/deprecated-prop-import.input.ts
+++ b/packages/datx-codemod/src/transforms/__testfixtures__/prop-to-attribute/deprecated-prop-import.input.ts
@@ -1,0 +1,3 @@
+// @ts-nocheck
+/* eslint-disable */
+import { Model, prop } from '@datx/core';

--- a/packages/datx-codemod/src/transforms/__testfixtures__/prop-to-attribute/deprecated-prop-import.output.ts
+++ b/packages/datx-codemod/src/transforms/__testfixtures__/prop-to-attribute/deprecated-prop-import.output.ts
@@ -1,0 +1,3 @@
+// @ts-nocheck
+/* eslint-disable */
+import { Model, Attribute } from '@datx/core';

--- a/packages/datx-codemod/src/transforms/prop-to-attribute.ts
+++ b/packages/datx-codemod/src/transforms/prop-to-attribute.ts
@@ -24,6 +24,20 @@ export default function transformer(file: FileInfo, api: API) {
         });
       }
     }
+
+    if (path.node.source.value === '@datx/core') {
+      if (path.node.specifiers) {
+        path.node.specifiers = path.node.specifiers.map((specifier) => {
+          if (specifier.type === 'ImportSpecifier') {
+            if (specifier.imported.name === 'prop') {
+              specifier.imported.name = 'Attribute';
+            }
+          }
+
+          return specifier;
+        });
+      }
+    }
   });
 
   root.find(j.ClassBody).forEach((path) => {

--- a/packages/datx-codemod/src/transforms/prop-to-attribute.ts
+++ b/packages/datx-codemod/src/transforms/prop-to-attribute.ts
@@ -2,6 +2,20 @@ import { API, FileInfo } from 'jscodeshift';
 
 export const parser = 'tsx';
 
+const replacePropWithAttribute = (path) => {
+  if (path.node.specifiers) {
+    path.node.specifiers = path.node.specifiers.map((specifier) => {
+      if (specifier.type === 'ImportSpecifier') {
+        if (specifier.imported.name === 'prop') {
+          specifier.imported.name = 'Attribute';
+        }
+      }
+
+      return specifier;
+    });
+  }
+};
+
 export default function transformer(file: FileInfo, api: API) {
   const j = api.jscodeshift;
   const root = j(file.source);
@@ -12,31 +26,11 @@ export default function transformer(file: FileInfo, api: API) {
     if (path.node.source.value === 'datx') {
       path.node.source.value = '@datx/core';
 
-      if (path.node.specifiers) {
-        path.node.specifiers = path.node.specifiers.map((specifier) => {
-          if (specifier.type === 'ImportSpecifier') {
-            if (specifier.imported.name === 'prop') {
-              specifier.imported.name = 'Attribute';
-            }
-          }
-
-          return specifier;
-        });
-      }
+      replacePropWithAttribute(path);
     }
 
     if (path.node.source.value === '@datx/core') {
-      if (path.node.specifiers) {
-        path.node.specifiers = path.node.specifiers.map((specifier) => {
-          if (specifier.type === 'ImportSpecifier') {
-            if (specifier.imported.name === 'prop') {
-              specifier.imported.name = 'Attribute';
-            }
-          }
-
-          return specifier;
-        });
-      }
+      replacePropWithAttribute(path);
     }
   });
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=**/__testfixtures__/**/*.ts


### PR DESCRIPTION
Add additional codemod transformation edgecase

```
import { Model, prop } from '@datx/core';
```
to
```
import { Model, Attribute } from '@datx/core';
```