### PR TITLE
Codemods jsonapi i request options changes

### DIFF
--- a/docs/migration-guide/codemods.md
+++ b/docs/migration-guide/codemods.md
@@ -120,7 +120,6 @@ class Pet extends Model {
 }
 ```
 
-
 ## Datx 2.0.0
 
 ### `prop-to-attribute`
@@ -225,3 +224,42 @@ import * as utils from '@datx/utils';
 import * as datx from '@datx/core';
 import * as jsonapi from '@datx/jsonapi';
 ```
+
+### `jsonapi-i-request-options-changes`
+
+The `IRequestOptions` interface has been changed to a different shape to allow for more flexibility. This codemod transforms the `IRequestOptions` interface to the new shape based on this migration guide [here](/docs/migration-guide/from-v1#json-api-irequestoptions-changes).
+
+For example, the following code:
+
+```ts
+store.fetch(Comment, 1, {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+```
+
+will be transformed to:
+
+```ts
+store.fetch(Comment, 1, {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});

--- a/packages/datx-codemod/src/bin/cli.ts
+++ b/packages/datx-codemod/src/bin/cli.ts
@@ -104,6 +104,10 @@ const TRANSFORMER_INQUIRER_CHOICES = [
     value: 'scoped-package-name',
   },
   {
+    name: 'jsonapi-i-request-options-changes: Migration to new IRequestOptions interface',
+    value: 'jsonapi-i-request-options-changes',
+  },
+  {
     name: 'attribute-to-field: In DatX 3.0.0, the `@Attribute` decorator is renamed to `@Field`',
     value: 'attribute-to-field',
   },

--- a/packages/datx-codemod/src/transforms/__testfixtures__/jsonapi-i-request-options-changes/general.input.ts
+++ b/packages/datx-codemod/src/transforms/__testfixtures__/jsonapi-i-request-options-changes/general.input.ts
@@ -1,0 +1,159 @@
+// @ts-nocheck
+/* eslint-disable */
+import { Collection, Model, View } from '@datx/core';
+import { jsonapiCollection, jsonapiModel } from '@datx/jsonapi';
+
+class Comment extends jsonapiModel(Model) {
+  public static type = 'comment';
+}
+
+class Store extends jsonapiCollection(Collection) {
+  public static types = [Comment];
+}
+
+const store = new Store();
+const comment = new Comment({ id: '1' }, store);
+const view = new View(Comment, store);
+
+store.fetch(Comment, 1, {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+store.fetchAll(Comment, {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+store.getOne(Comment, {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+store.getMany(Comment, {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+store.getAll(Comment, {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+store.request(Comment, 'GET', 'url', {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+store.removeOne(Comment, 1, {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+store.removeOne(Comment, {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+store.removeAll(Comment, {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+comment.save({
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+comment.destroy({
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+view.getOne(1, {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+view.getAll({
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+
+const someRandomFunctionWithSimilarInterface = (options) => {};
+
+someRandomFunctionWithSimilarInterface({
+  notIRequestOptionProp: 'test',
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});

--- a/packages/datx-codemod/src/transforms/__testfixtures__/jsonapi-i-request-options-changes/general.input.ts
+++ b/packages/datx-codemod/src/transforms/__testfixtures__/jsonapi-i-request-options-changes/general.input.ts
@@ -157,3 +157,7 @@ someRandomFunctionWithSimilarInterface({
   params: [{ key: 'key', value: 'value' }],
   skipCache: true,
 });
+
+const emptyObject = {
+  ...{},
+};

--- a/packages/datx-codemod/src/transforms/__testfixtures__/jsonapi-i-request-options-changes/general.output.ts
+++ b/packages/datx-codemod/src/transforms/__testfixtures__/jsonapi-i-request-options-changes/general.output.ts
@@ -261,3 +261,7 @@ someRandomFunctionWithSimilarInterface({
   params: [{ key: 'key', value: 'value' }],
   skipCache: true,
 });
+
+const emptyObject = {
+  ...{},
+};

--- a/packages/datx-codemod/src/transforms/__testfixtures__/jsonapi-i-request-options-changes/general.output.ts
+++ b/packages/datx-codemod/src/transforms/__testfixtures__/jsonapi-i-request-options-changes/general.output.ts
@@ -1,0 +1,263 @@
+// @ts-nocheck
+/* eslint-disable */
+import { Collection, Model, View } from '@datx/core';
+import { jsonapiCollection, jsonapiModel } from '@datx/jsonapi';
+
+class Comment extends jsonapiModel(Model) {
+  public static type = 'comment';
+}
+
+class Store extends jsonapiCollection(Collection) {
+  public static types = [Comment];
+}
+
+const store = new Store();
+const comment = new Comment({ id: '1' }, store);
+const view = new View(Comment, store);
+
+store.fetch(Comment, 1, {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+store.fetchAll(Comment, {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+store.getOne(Comment, {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+store.getMany(Comment, {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+store.getAll(Comment, {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+store.request(Comment, 'GET', 'url', {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+store.removeOne(Comment, 1, {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+store.removeOne(Comment, {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+store.removeAll(Comment, {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+comment.save({
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+comment.destroy({
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+view.getOne(1, {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+view.getAll({
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
+
+const someRandomFunctionWithSimilarInterface = (options) => {};
+
+someRandomFunctionWithSimilarInterface({
+  notIRequestOptionProp: 'test',
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});

--- a/packages/datx-codemod/src/transforms/__tests__/jsonapi-i-request-options-changes.test.ts
+++ b/packages/datx-codemod/src/transforms/__tests__/jsonapi-i-request-options-changes.test.ts
@@ -1,0 +1,17 @@
+/* global jest */
+jest.autoMockOff();
+import { defineTest } from 'jscodeshift/dist/testUtils';
+import { readdirSync } from 'fs';
+import { join } from 'path';
+
+const fixtureDir = 'jsonapi-i-request-options-changes';
+const fixtureDirPath = join(__dirname, '..', '__testfixtures__', fixtureDir);
+const fixtures = readdirSync(fixtureDirPath)
+  .filter((file) => file.endsWith('.input.ts'))
+  .map((file) => file.replace('.input.ts', ''));
+
+for (const fixture of fixtures) {
+  const prefix = `${fixtureDir}/${fixture}`;
+
+  defineTest(__dirname, fixtureDir, null, prefix, { parser: 'ts' });
+}

--- a/packages/datx-codemod/src/transforms/jsonapi-i-request-options-changes.ts
+++ b/packages/datx-codemod/src/transforms/jsonapi-i-request-options-changes.ts
@@ -1,0 +1,112 @@
+import { API, FileInfo } from 'jscodeshift';
+
+export const parser = 'tsx';
+
+const oldIRequestOptionsPropNames = [
+  'headers',
+  'include',
+  'filter',
+  'sort',
+  'fields',
+  'params',
+  'skipCache',
+];
+
+export default function transformer(file: FileInfo, api: API) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  const oldIRequestOptionsObjectLiterals = root.find(j.ObjectExpression).filter((path) => {
+    const props = path.get('properties');
+    const propNames = props.map((prop) => prop.node.key.name);
+
+    // Filter only headers, include, filter, sort, fields, params, skipCache props
+    const allowedPropNames = propNames.filter((name) => oldIRequestOptionsPropNames.includes(name));
+
+    if (allowedPropNames.length === 0) {
+      return false;
+    }
+
+    // If object contains any of other props than it's not IRequestOptions object
+    if (allowedPropNames.length > 0) {
+      if (propNames.length !== allowedPropNames.length) {
+        return false;
+      }
+
+      return true;
+    }
+  });
+
+  // Convert old IRequestOptions object literals to new IRequestOptions object literals
+  oldIRequestOptionsObjectLiterals.forEach((path) => {
+    const props = path.get('properties');
+
+    const newPropsNodes = [];
+
+    for (const prop of props.value) {
+      const name = prop.key.name;
+
+      if (name === 'headers') {
+        const networkConfig = newPropsNodes.find((prop) => prop.key.name === 'networkConfig');
+
+        if (networkConfig) {
+          networkConfig.value.properties.push(prop);
+        } else {
+          newPropsNodes.push(
+            j.objectProperty(j.identifier('networkConfig'), j.objectExpression([prop])),
+          );
+        }
+      }
+
+      if (
+        name === 'include' ||
+        name === 'filter' ||
+        name === 'sort' ||
+        name === 'fields' ||
+        name === 'params'
+      ) {
+        const queryParams = newPropsNodes.find((prop) => prop.key.name === 'queryParams');
+
+        if (queryParams) {
+          if (name === 'params') {
+            queryParams.value.properties.push(j.objectProperty(j.identifier('custom'), prop.value));
+          } else {
+            queryParams.value.properties.push(prop);
+          }
+        } else {
+          if (name === 'params') {
+            newPropsNodes.push(
+              j.objectProperty(
+                j.identifier('queryParams'),
+                j.objectExpression([j.objectProperty(j.identifier('custom'), prop.value)]),
+              ),
+            );
+          } else {
+            newPropsNodes.push(
+              j.objectProperty(j.identifier('queryParams'), j.objectExpression([prop])),
+            );
+          }
+        }
+      }
+
+      if (name === 'skipCache') {
+        const cacheOptions = newPropsNodes.find((prop) => prop.key.name === 'cacheOptions');
+
+        if (cacheOptions) {
+          cacheOptions.value.properties.push(prop);
+        } else {
+          newPropsNodes.push(
+            j.objectProperty(j.identifier('cacheOptions'), j.objectExpression([prop])),
+          );
+        }
+      }
+    }
+
+    path.replace(j.objectExpression(newPropsNodes));
+  });
+
+  return root.toSource({
+    quote: 'single',
+    trailingComma: true,
+  });
+}

--- a/packages/datx-codemod/src/transforms/jsonapi-i-request-options-changes.ts
+++ b/packages/datx-codemod/src/transforms/jsonapi-i-request-options-changes.ts
@@ -104,19 +104,17 @@ export default function transformer(file: FileInfo, api: API) {
           } else {
             queryParams.value.properties.push(prop);
           }
+        } else if (name === 'params') {
+          newPropsNodes.push(
+            j.objectProperty(
+              j.identifier('queryParams'),
+              j.objectExpression([j.objectProperty(j.identifier('custom'), prop.value)]),
+            ),
+          );
         } else {
-          if (name === 'params') {
-            newPropsNodes.push(
-              j.objectProperty(
-                j.identifier('queryParams'),
-                j.objectExpression([j.objectProperty(j.identifier('custom'), prop.value)]),
-              ),
-            );
-          } else {
-            newPropsNodes.push(
-              j.objectProperty(j.identifier('queryParams'), j.objectExpression([prop])),
-            );
-          }
+          newPropsNodes.push(
+            j.objectProperty(j.identifier('queryParams'), j.objectExpression([prop])),
+          );
         }
       }
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=**/__testfixtures__/**/*.ts

--- a/website/versioned_docs/version-2.0.0/migration-guide/codemods.md
+++ b/website/versioned_docs/version-2.0.0/migration-guide/codemods.md
@@ -121,7 +121,6 @@ class Pet extends Model {
 }
 ```
 
-
 ## Datx 2.0.0
 
 ### `prop-to-attribute`
@@ -225,4 +224,44 @@ will be transformed to:
 import * as utils from '@datx/utils';
 import * as datx from '@datx/core';
 import * as jsonapi from '@datx/jsonapi';
+```
+
+### `jsonapi-i-request-options-changes`
+
+The `IRequestOptions` interface has been changed to a different shape to allow for more flexibility. This codemod transforms the `IRequestOptions` interface to the new shape based on this migration guide [here](/docs/migration-guide/from-v1#json-api-irequestoptions-changes).
+
+For example, the following code:
+
+```ts
+store.fetch(Comment, 1, {
+  headers: {},
+  include: ['author'],
+  filter: { key: 'value' },
+  sort: 'name',
+  fields: { key: 'value' },
+  params: [{ key: 'key', value: 'value' }],
+  skipCache: true,
+});
+```
+
+will be transformed to:
+
+```ts
+store.fetch(Comment, 1, {
+  networkConfig: {
+    headers: {},
+  },
+
+  queryParams: {
+    include: ['author'],
+    filter: { key: 'value' },
+    sort: 'name',
+    fields: { key: 'value' },
+    custom: [{ key: 'key', value: 'value' }],
+  },
+
+  cacheOptions: {
+    skipCache: true,
+  },
+});
 ```

--- a/website/versioned_sidebars/version-2.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-2.0.0-sidebars.json
@@ -66,7 +66,6 @@
       "version-2.0.0-migration-guide/from-v1",
       "version-2.0.0-migration-guide/codemods"
     ],
-
     "Testing": ["version-2.0.0-testing/test-data-factory"],
     "Troubleshooting": ["version-2.0.0-troubleshooting/known-issues"]
   },


### PR DESCRIPTION
The `IRequestOptions` interface has been changed to a different shape to allow for more flexibility. This codemod transforms the `IRequestOptions` interface to the new shape based on this migration guide [here](https://datx.dev/docs/migration-guide/from-v1#json-api-irequestoptions-changes).
